### PR TITLE
Send to Email/Kindle, EPUB repair, enrichment fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +94,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +118,17 @@ dependencies = [
  "blake2",
  "cpufeatures",
  "password-hash",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -268,12 +296,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -301,6 +350,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -363,6 +422,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "core-foundation-sys"
@@ -435,6 +500,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +514,15 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -495,6 +575,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "email-encoding"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9298e6504d9b9e780ed3f7dfd43a61be8cd0e09eb07f7706a945b0072b6670b6"
+dependencies = [
+ "base64",
+ "memchr",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +627,12 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -705,9 +807,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -773,6 +888,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
 ]
 
 [[package]]
@@ -994,6 +1120,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "id3"
 version = "1.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,6 +1179,17 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1078,6 +1221,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,6 +1249,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "lettre"
+version = "0.11.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+dependencies = [
+ "async-trait",
+ "base64",
+ "email-encoding",
+ "email_address",
+ "fastrand",
+ "futures-io",
+ "futures-util",
+ "hostname",
+ "httpdate",
+ "idna",
+ "mime",
+ "nom",
+ "percent-encoding",
+ "quoted_printable",
+ "rustls",
+ "socket2",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "url",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1229,6 +1417,7 @@ dependencies = [
  "getrandom 0.2.17",
  "hex",
  "image",
+ "lettre",
  "libc",
  "livrarr-db",
  "livrarr-domain",
@@ -1252,6 +1441,7 @@ dependencies = [
  "tracing-subscriber",
  "trait-variant",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]
@@ -1262,6 +1452,7 @@ dependencies = [
  "livrarr-domain",
  "mp4ameta",
  "quick-xml",
+ "repub",
  "thiserror",
  "tokio",
  "zip",
@@ -1287,6 +1478,27 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "matchers"
@@ -1373,6 +1585,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453e991b2efe96c288cbc2d03a19e353504294559ecb6c03067fff5bd824616d"
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1396,6 +1617,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -1480,6 +1707,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,12 +1786,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1646,10 +1899,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quoted_printable"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
+
+[[package]]
 name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1746,6 +2011,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "repub"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "quick-xml",
+ "thiserror",
+ "uuid",
+ "zip",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1831,6 +2107,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -1877,6 +2154,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2338,6 +2621,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2651,6 +2953,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2685,6 +2993,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -2724,6 +3043,15 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -2787,6 +3115,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -3046,12 +3408,103 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
 
 [[package]]
 name = "yoke"
@@ -3122,6 +3575,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
@@ -3162,15 +3629,28 @@ version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
 dependencies = [
+ "aes",
  "arbitrary",
+ "bzip2",
+ "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
+ "deflate64",
  "displaydoc",
  "flate2",
+ "getrandom 0.3.4",
+ "hmac",
  "indexmap",
+ "lzma-rs",
  "memchr",
+ "pbkdf2",
+ "sha1",
  "thiserror",
+ "time",
+ "xz2",
+ "zeroize",
  "zopfli",
+ "zstd",
 ]
 
 [[package]]
@@ -3189,6 +3669,34 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/crates/livrarr-db/migrations/011_add_email_config.sql
+++ b/crates/livrarr-db/migrations/011_add_email_config.sql
@@ -1,0 +1,17 @@
+-- Email / Send to Kindle configuration (singleton)
+CREATE TABLE IF NOT EXISTS email_config (
+    id              INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+    enabled         BOOLEAN NOT NULL DEFAULT 0,
+    smtp_host       TEXT NOT NULL DEFAULT 'smtp.gmail.com',
+    smtp_port       INTEGER NOT NULL DEFAULT 587,
+    encryption      TEXT NOT NULL DEFAULT 'starttls',
+    username        TEXT,
+    password        TEXT,
+    from_address    TEXT,
+    recipient_email TEXT,
+    send_on_import  BOOLEAN NOT NULL DEFAULT 0
+);
+
+INSERT OR IGNORE INTO email_config (id) VALUES (1);
+
+UPDATE _livrarr_meta SET value = '11' WHERE key = 'schema_version';

--- a/crates/livrarr-db/src/lib.rs
+++ b/crates/livrarr-db/src/lib.rs
@@ -731,6 +731,15 @@ pub trait ConfigDb: Send + Sync {
         &self,
         req: UpdateMetadataConfigRequest,
     ) -> Result<MetadataConfig, DbError>;
+
+    /// Get email config.
+    async fn get_email_config(&self) -> Result<EmailConfig, DbError>;
+
+    /// Update email config.
+    async fn update_email_config(
+        &self,
+        req: UpdateEmailConfigRequest,
+    ) -> Result<EmailConfig, DbError>;
 }
 
 pub struct NamingConfig {
@@ -775,6 +784,31 @@ pub struct UpdateProwlarrConfigRequest {
     pub url: Option<String>,
     pub api_key: Option<String>,
     pub enabled: Option<bool>,
+}
+
+#[derive(Default)]
+pub struct EmailConfig {
+    pub enabled: bool,
+    pub smtp_host: String,
+    pub smtp_port: i32,
+    pub encryption: String,
+    pub username: Option<String>,
+    pub password: Option<String>,
+    pub from_address: Option<String>,
+    pub recipient_email: Option<String>,
+    pub send_on_import: bool,
+}
+
+pub struct UpdateEmailConfigRequest {
+    pub enabled: Option<bool>,
+    pub smtp_host: Option<String>,
+    pub smtp_port: Option<i32>,
+    pub encryption: Option<String>,
+    pub username: Option<String>,
+    pub password: Option<String>,
+    pub from_address: Option<String>,
+    pub recipient_email: Option<String>,
+    pub send_on_import: Option<bool>,
 }
 
 pub struct UpdateMetadataConfigRequest {

--- a/crates/livrarr-db/src/sqlite_config.rs
+++ b/crates/livrarr-db/src/sqlite_config.rs
@@ -3,9 +3,9 @@ use sqlx::Row;
 use crate::sqlite::SqliteDb;
 use crate::sqlite_common::map_db_err;
 use crate::{
-    ConfigDb, DbError, LlmProvider, MediaManagementConfig, MetadataConfig, NamingConfig,
-    ProwlarrConfig, UpdateMediaManagementConfigRequest, UpdateMetadataConfigRequest,
-    UpdateProwlarrConfigRequest,
+    ConfigDb, DbError, EmailConfig, LlmProvider, MediaManagementConfig, MetadataConfig,
+    NamingConfig, ProwlarrConfig, UpdateEmailConfigRequest, UpdateMediaManagementConfigRequest,
+    UpdateMetadataConfigRequest, UpdateProwlarrConfigRequest,
 };
 
 fn parse_llm_provider(s: &str) -> Result<LlmProvider, DbError> {
@@ -220,5 +220,81 @@ impl ConfigDb for SqliteDb {
         .map_err(map_db_err)?;
 
         self.get_metadata_config().await
+    }
+
+    async fn get_email_config(&self) -> Result<EmailConfig, DbError> {
+        let row = sqlx::query("SELECT * FROM email_config WHERE id = 1")
+            .fetch_one(self.pool())
+            .await
+            .map_err(map_db_err)?;
+
+        Ok(EmailConfig {
+            enabled: row
+                .try_get::<bool, _>("enabled")
+                .map_err(|e| DbError::Io(Box::new(e)))?,
+            smtp_host: row
+                .try_get("smtp_host")
+                .map_err(|e| DbError::Io(Box::new(e)))?,
+            smtp_port: row
+                .try_get("smtp_port")
+                .map_err(|e| DbError::Io(Box::new(e)))?,
+            encryption: row
+                .try_get("encryption")
+                .map_err(|e| DbError::Io(Box::new(e)))?,
+            username: row
+                .try_get("username")
+                .map_err(|e| DbError::Io(Box::new(e)))?,
+            password: row
+                .try_get("password")
+                .map_err(|e| DbError::Io(Box::new(e)))?,
+            from_address: row
+                .try_get("from_address")
+                .map_err(|e| DbError::Io(Box::new(e)))?,
+            recipient_email: row
+                .try_get("recipient_email")
+                .map_err(|e| DbError::Io(Box::new(e)))?,
+            send_on_import: row
+                .try_get::<bool, _>("send_on_import")
+                .map_err(|e| DbError::Io(Box::new(e)))?,
+        })
+    }
+
+    async fn update_email_config(
+        &self,
+        req: UpdateEmailConfigRequest,
+    ) -> Result<EmailConfig, DbError> {
+        let current = self.get_email_config().await?;
+
+        let enabled = req.enabled.unwrap_or(current.enabled);
+        let smtp_host = req.smtp_host.unwrap_or(current.smtp_host);
+        let smtp_port = req.smtp_port.unwrap_or(current.smtp_port);
+        let encryption = req.encryption.unwrap_or(current.encryption);
+        let username = req.username.or(current.username);
+        let password = req.password.or(current.password);
+        let from_address = req.from_address.or(current.from_address);
+        let recipient_email = req.recipient_email.or(current.recipient_email);
+        let send_on_import = req.send_on_import.unwrap_or(current.send_on_import);
+
+        sqlx::query(
+            "UPDATE email_config SET \
+             enabled = ?, smtp_host = ?, smtp_port = ?, encryption = ?, \
+             username = ?, password = ?, from_address = ?, recipient_email = ?, \
+             send_on_import = ? \
+             WHERE id = 1",
+        )
+        .bind(enabled)
+        .bind(&smtp_host)
+        .bind(smtp_port)
+        .bind(&encryption)
+        .bind(&username)
+        .bind(&password)
+        .bind(&from_address)
+        .bind(&recipient_email)
+        .bind(send_on_import)
+        .execute(self.pool())
+        .await
+        .map_err(map_db_err)?;
+
+        self.get_email_config().await
     }
 }

--- a/crates/livrarr-server/Cargo.toml
+++ b/crates/livrarr-server/Cargo.toml
@@ -40,6 +40,8 @@ quick-xml = "0.37"
 urlencoding = "2"
 reqwest = { version = "0.12", default-features = false, features = ["multipart", "rustls-tls"] }
 image = { version = "0.25", default-features = false, features = ["jpeg"] }
+lettre = { version = "0.11", default-features = false, features = ["builder", "smtp-transport", "tokio1-rustls-tls", "pool", "hostname", "tracing"] }
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 livrarr-db = { workspace = true, features = ["test-helpers"] }

--- a/crates/livrarr-server/src/api_secondary_impl.rs
+++ b/crates/livrarr-server/src/api_secondary_impl.rs
@@ -10,8 +10,8 @@ use livrarr_db::{
     CreateLibraryItemDbRequest, CreateNotificationDbRequest, CreateUserDbRequest,
     CreateWorkDbRequest, DownloadClientDb, HistoryDb, HistoryFilter, LibraryItemDb, NotificationDb,
     RemotePathMappingDb, RootFolderDb, UpdateAuthorDbRequest, UpdateDownloadClientDbRequest,
-    UpdateMediaManagementConfigRequest, UpdateMetadataConfigRequest, UpdateProwlarrConfigRequest,
-    UserDb, WorkDb,
+    UpdateEmailConfigRequest, UpdateMediaManagementConfigRequest, UpdateMetadataConfigRequest,
+    UpdateProwlarrConfigRequest, UserDb, WorkDb,
 };
 
 /// Map DbError to the semantically correct ApiError.
@@ -562,6 +562,53 @@ impl ConfigApi for SecondaryApiImpl {
             llm_model: c.llm_model,
             audnexus_url: c.audnexus_url,
             languages: c.languages,
+        })
+    }
+
+    async fn get_email(&self) -> Result<EmailConfigResponse, ApiError> {
+        let c = self.db.get_email_config().await.map_err(db_err)?;
+        Ok(EmailConfigResponse {
+            enabled: c.enabled,
+            smtp_host: c.smtp_host,
+            smtp_port: c.smtp_port,
+            encryption: c.encryption,
+            username: c.username,
+            password_set: c.password.is_some(),
+            from_address: c.from_address,
+            recipient_email: c.recipient_email,
+            send_on_import: c.send_on_import,
+        })
+    }
+
+    async fn update_email(
+        &self,
+        req: UpdateEmailApiRequest,
+    ) -> Result<EmailConfigResponse, ApiError> {
+        let c = self
+            .db
+            .update_email_config(UpdateEmailConfigRequest {
+                enabled: req.enabled,
+                smtp_host: req.smtp_host,
+                smtp_port: req.smtp_port,
+                encryption: req.encryption,
+                username: req.username,
+                password: req.password,
+                from_address: req.from_address,
+                recipient_email: req.recipient_email,
+                send_on_import: req.send_on_import,
+            })
+            .await
+            .map_err(db_err)?;
+        Ok(EmailConfigResponse {
+            enabled: c.enabled,
+            smtp_host: c.smtp_host,
+            smtp_port: c.smtp_port,
+            encryption: c.encryption,
+            username: c.username,
+            password_set: c.password.is_some(),
+            from_address: c.from_address,
+            recipient_email: c.recipient_email,
+            send_on_import: c.send_on_import,
         })
     }
 }

--- a/crates/livrarr-server/src/handlers/config.rs
+++ b/crates/livrarr-server/src/handlers/config.rs
@@ -243,3 +243,66 @@ pub async fn update_prowlarr(
         enabled: c.enabled,
     }))
 }
+
+/// GET /api/v1/config/email
+pub async fn get_email(
+    State(state): State<AppState>,
+) -> Result<Json<crate::EmailConfigResponse>, ApiError> {
+    let c = state.db.get_email_config().await?;
+    Ok(Json(crate::EmailConfigResponse {
+        enabled: c.enabled,
+        smtp_host: c.smtp_host,
+        smtp_port: c.smtp_port,
+        encryption: c.encryption,
+        username: c.username,
+        password_set: c.password.is_some(),
+        from_address: c.from_address,
+        recipient_email: c.recipient_email,
+        send_on_import: c.send_on_import,
+    }))
+}
+
+/// PUT /api/v1/config/email
+pub async fn update_email(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+    Json(req): Json<crate::UpdateEmailApiRequest>,
+) -> Result<Json<crate::EmailConfigResponse>, ApiError> {
+    let c = state
+        .db
+        .update_email_config(livrarr_db::UpdateEmailConfigRequest {
+            enabled: req.enabled,
+            smtp_host: req.smtp_host,
+            smtp_port: req.smtp_port,
+            encryption: req.encryption,
+            username: req.username,
+            password: req.password,
+            from_address: req.from_address,
+            recipient_email: req.recipient_email,
+            send_on_import: req.send_on_import,
+        })
+        .await?;
+    Ok(Json(crate::EmailConfigResponse {
+        enabled: c.enabled,
+        smtp_host: c.smtp_host,
+        smtp_port: c.smtp_port,
+        encryption: c.encryption,
+        username: c.username,
+        password_set: c.password.is_some(),
+        from_address: c.from_address,
+        recipient_email: c.recipient_email,
+        send_on_import: c.send_on_import,
+    }))
+}
+
+/// POST /api/v1/config/email/test
+pub async fn test_email(
+    State(state): State<AppState>,
+    _admin: RequireAdmin,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let cfg = state.db.get_email_config().await?;
+    super::email::send_test(&cfg)
+        .await
+        .map_err(ApiError::BadRequest)?;
+    Ok(Json(serde_json::json!({ "success": true })))
+}

--- a/crates/livrarr-server/src/handlers/email.rs
+++ b/crates/livrarr-server/src/handlers/email.rs
@@ -1,0 +1,152 @@
+//! Shared email sending utilities for Send to Kindle / eReader.
+
+use lettre::message::{header::ContentType, Attachment, MultiPart, SinglePart};
+use lettre::transport::smtp::authentication::Credentials;
+use lettre::{AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor};
+use livrarr_db::EmailConfig;
+
+/// Accepted file extensions for email delivery.
+pub const ACCEPTED_EXTENSIONS: &[&str] =
+    &["epub", "pdf", "docx", "doc", "rtf", "htm", "html", "txt"];
+
+/// Maximum file size for email attachments (50 MB).
+pub const MAX_EMAIL_SIZE: i64 = 50 * 1024 * 1024;
+
+/// Build an SMTP transport from an EmailConfig.
+fn build_transport(
+    cfg: &EmailConfig,
+    creds: Credentials,
+) -> Result<AsyncSmtpTransport<Tokio1Executor>, String> {
+    let mailer = match cfg.encryption.as_str() {
+        "ssl" => AsyncSmtpTransport::<Tokio1Executor>::relay(&cfg.smtp_host)
+            .map_err(|e| format!("SMTP relay error: {e}"))?
+            .port(cfg.smtp_port as u16)
+            .credentials(creds)
+            .build(),
+        "starttls" => AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&cfg.smtp_host)
+            .map_err(|e| format!("SMTP STARTTLS error: {e}"))?
+            .port(cfg.smtp_port as u16)
+            .credentials(creds)
+            .build(),
+        _ => AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(&cfg.smtp_host)
+            .port(cfg.smtp_port as u16)
+            .credentials(creds)
+            .build(),
+    };
+    Ok(mailer)
+}
+
+/// Validate email config has all required fields. Returns (from_address, recipient, password, username).
+pub fn validate_config(cfg: &EmailConfig) -> Result<(String, String, String, String), String> {
+    let from_address = cfg
+        .from_address
+        .clone()
+        .ok_or("Email 'From Address' not configured")?;
+    let recipient = cfg
+        .recipient_email
+        .clone()
+        .ok_or("Kindle email not configured")?;
+    let password = cfg.password.clone().ok_or("SMTP password not configured")?;
+    let username = cfg.username.clone().unwrap_or_else(|| from_address.clone());
+    Ok((from_address, recipient, password, username))
+}
+
+/// Generate a proper Message-ID using the sender's domain.
+fn make_message_id(from_address: &str) -> String {
+    let sender_domain = from_address.split('@').nth(1).unwrap_or("livrarr.local");
+    format!(
+        "<{}.{}@{}>",
+        chrono::Utc::now().timestamp(),
+        uuid::Uuid::new_v4(),
+        sender_domain
+    )
+}
+
+/// MIME type for a file extension.
+pub fn mime_for_ext(ext: &str) -> &'static str {
+    match ext {
+        "epub" => "application/epub+zip",
+        "pdf" => "application/pdf",
+        "docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "doc" => "application/msword",
+        "rtf" => "application/rtf",
+        "htm" | "html" => "text/html",
+        "txt" => "text/plain",
+        _ => "application/octet-stream",
+    }
+}
+
+/// Send a test email (no attachment) to verify SMTP connectivity.
+pub async fn send_test(cfg: &EmailConfig) -> Result<(), String> {
+    let (from_address, recipient, password, username) = validate_config(cfg)?;
+    let message_id = make_message_id(&from_address);
+
+    let email = Message::builder()
+        .message_id(Some(message_id))
+        .from(
+            from_address
+                .parse()
+                .map_err(|e| format!("Invalid 'From' address: {e}"))?,
+        )
+        .to(recipient
+            .parse()
+            .map_err(|e| format!("Invalid recipient address: {e}"))?)
+        .subject("Livrarr Test Email")
+        .singlepart(SinglePart::plain(String::from(
+            "This is a test email from Livrarr. If you received this, your email configuration is working correctly.",
+        )))
+        .map_err(|e| format!("Failed to build email: {e}"))?;
+
+    let creds = Credentials::new(username, password);
+    let mailer = build_transport(cfg, creds)?;
+
+    mailer
+        .send(email)
+        .await
+        .map_err(|e| format!("Failed to send: {e}"))?;
+
+    Ok(())
+}
+
+/// Send a file as an email attachment.
+pub async fn send_file(
+    cfg: &EmailConfig,
+    file_bytes: Vec<u8>,
+    filename: &str,
+    ext: &str,
+) -> Result<(), String> {
+    let (from_address, recipient, password, username) = validate_config(cfg)?;
+    let message_id = make_message_id(&from_address);
+    let mime = mime_for_ext(ext);
+
+    let attachment = Attachment::new(filename.to_string())
+        .body(file_bytes, mime.parse().unwrap_or(ContentType::TEXT_PLAIN));
+
+    let email = Message::builder()
+        .message_id(Some(message_id))
+        .from(
+            from_address
+                .parse()
+                .map_err(|e| format!("Invalid 'From' address: {e}"))?,
+        )
+        .to(recipient
+            .parse()
+            .map_err(|e| format!("Invalid recipient address: {e}"))?)
+        .subject(String::new())
+        .multipart(
+            MultiPart::mixed()
+                .singlepart(SinglePart::plain(String::from("Sent from Livrarr")))
+                .singlepart(attachment),
+        )
+        .map_err(|e| format!("Failed to build email: {e}"))?;
+
+    let creds = Credentials::new(username, password);
+    let mailer = build_transport(cfg, creds)?;
+
+    mailer
+        .send(email)
+        .await
+        .map_err(|e| format!("Failed to send: {e}"))?;
+
+    Ok(())
+}

--- a/crates/livrarr-server/src/handlers/enrichment.rs
+++ b/crates/livrarr-server/src/handlers/enrichment.rs
@@ -248,6 +248,11 @@ pub async fn enrich_work(state: &AppState, work: &Work) -> EnrichmentOutcome {
         }
     }
 
+    // Default language from metadata config if not set by any provider.
+    if req.language.is_none() {
+        req.language = cfg.languages.first().cloned();
+    }
+
     // --- Download cover if we got a new URL ---
     if let Some(ref url) = req.cover_url {
         let covers_dir = state.data_dir.join("covers");

--- a/crates/livrarr-server/src/handlers/import.rs
+++ b/crates/livrarr-server/src/handlers/import.rs
@@ -521,6 +521,42 @@ pub async fn import_single_file(
         }
     }
 
+    // Auto-send to email/Kindle on import (ebooks only, non-fatal).
+    if media_type == MediaType::Ebook {
+        if let Ok(email_cfg) = state.db.get_email_config().await {
+            if email_cfg.send_on_import && email_cfg.enabled {
+                let ext = source
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .unwrap_or("")
+                    .to_lowercase();
+                if super::email::ACCEPTED_EXTENSIONS.contains(&ext.as_str())
+                    && file_size <= super::email::MAX_EMAIL_SIZE
+                {
+                    let target_str = target_path.to_string();
+                    match tokio::fs::read(&target_str).await {
+                        Ok(bytes) => {
+                            let filename = std::path::Path::new(&target_str)
+                                .file_name()
+                                .and_then(|f| f.to_str())
+                                .unwrap_or("book");
+                            if let Err(e) =
+                                super::email::send_file(&email_cfg, bytes, filename, &ext).await
+                            {
+                                tracing::warn!(file = %target_str, "Auto-send email failed: {e}");
+                            } else {
+                                tracing::info!(file = %target_str, "Auto-sent to email on import");
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(file = %target_str, "Auto-send: failed to read file: {e}");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     match tag_warning {
         Some(w) => Err(ImportFileError::Warning(w)),
         None => Ok(()),

--- a/crates/livrarr-server/src/handlers/mod.rs
+++ b/crates/livrarr-server/src/handlers/mod.rs
@@ -2,6 +2,7 @@ pub mod auth;
 pub mod author;
 pub mod config;
 pub mod download_client;
+pub mod email;
 pub mod enrichment;
 pub mod filesystem;
 pub mod history;

--- a/crates/livrarr-server/src/handlers/work.rs
+++ b/crates/livrarr-server/src/handlers/work.rs
@@ -877,15 +877,30 @@ pub async fn refresh_all(
 
             match outcome {
                 Ok(o) => {
-                    if state
+                    match state
                         .db
                         .update_work_enrichment(user_id, work.id, o.request)
                         .await
-                        .is_ok()
                     {
-                        enriched += 1;
-                    } else {
-                        failed += 1;
+                        Ok(enriched_work) => {
+                            enriched += 1;
+                            // Retag library files with updated metadata.
+                            if let Ok(taggable) =
+                                state.db.list_taggable_items_by_work(user_id, work.id).await
+                            {
+                                if !taggable.is_empty() {
+                                    let _ = super::import::retag_library_items(
+                                        &state,
+                                        &enriched_work,
+                                        &taggable,
+                                    )
+                                    .await;
+                                }
+                            }
+                        }
+                        Err(_) => {
+                            failed += 1;
+                        }
                     }
                 }
                 Err(_) => {

--- a/crates/livrarr-server/src/handlers/workfile.rs
+++ b/crates/livrarr-server/src/handlers/workfile.rs
@@ -3,7 +3,7 @@ use axum::Json;
 
 use crate::state::AppState;
 use crate::{ApiError, AuthContext, LibraryItemResponse};
-use livrarr_db::LibraryItemDb;
+use livrarr_db::{ConfigDb, LibraryItemDb, RootFolderDb};
 
 fn to_response(li: &livrarr_domain::LibraryItem) -> LibraryItemResponse {
     LibraryItemResponse {
@@ -42,4 +42,70 @@ pub async fn delete(
 ) -> Result<(), ApiError> {
     let _item = state.db.delete_library_item(ctx.user.id, id).await?;
     Ok(())
+}
+
+/// POST /api/v1/workfile/:id/send-email
+pub async fn send_email(
+    State(state): State<AppState>,
+    ctx: AuthContext,
+    Path(id): Path<i64>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let item = state.db.get_library_item(ctx.user.id, id).await?;
+    let root_folder = state.db.get_root_folder(item.root_folder_id).await?;
+    let abs_path = std::path::Path::new(&root_folder.path).join(&item.path);
+    let cfg = state.db.get_email_config().await?;
+
+    let ext = abs_path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+
+    if !super::email::ACCEPTED_EXTENSIONS.contains(&ext.as_str()) {
+        return Err(ApiError::BadRequest(format!(
+            "Format '.{ext}' not accepted. Supported: EPUB, PDF, DOCX, RTF, TXT, HTML."
+        )));
+    }
+
+    if item.file_size > super::email::MAX_EMAIL_SIZE {
+        return Err(ApiError::BadRequest(format!(
+            "File exceeds the 50 MB email limit ({})",
+            format_bytes(item.file_size)
+        )));
+    }
+
+    let file_bytes = tokio::fs::read(&abs_path).await.map_err(|e| {
+        ApiError::Internal(format!("Failed to read file {}: {e}", abs_path.display()))
+    })?;
+
+    let filename = abs_path
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or("book");
+
+    super::email::send_file(&cfg, file_bytes, filename, &ext)
+        .await
+        .map_err(|e| {
+            tracing::error!("Email send failed: {e}");
+            ApiError::Internal(e)
+        })?;
+
+    tracing::info!(file = %item.path, "Email sent");
+    Ok(Json(serde_json::json!({ "success": true })))
+}
+
+fn format_bytes(bytes: i64) -> String {
+    const KB: f64 = 1024.0;
+    const MB: f64 = KB * 1024.0;
+    const GB: f64 = MB * 1024.0;
+    let b = bytes as f64;
+    if b >= GB {
+        format!("{:.1} GB", b / GB)
+    } else if b >= MB {
+        format!("{:.1} MB", b / MB)
+    } else if b >= KB {
+        format!("{:.1} KB", b / KB)
+    } else {
+        format!("{bytes} B")
+    }
 }

--- a/crates/livrarr-server/src/lib.rs
+++ b/crates/livrarr-server/src/lib.rs
@@ -954,6 +954,40 @@ pub struct UpdateProwlarrApiRequest {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct EmailConfigResponse {
+    pub enabled: bool,
+    pub smtp_host: String,
+    pub smtp_port: i32,
+    pub encryption: String,
+    pub username: Option<String>,
+    pub password_set: bool,
+    pub from_address: Option<String>,
+    pub recipient_email: Option<String>,
+    pub send_on_import: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateEmailApiRequest {
+    pub enabled: Option<bool>,
+    pub smtp_host: Option<String>,
+    pub smtp_port: Option<i32>,
+    pub encryption: Option<String>,
+    pub username: Option<String>,
+    pub password: Option<String>,
+    pub from_address: Option<String>,
+    pub recipient_email: Option<String>,
+    pub send_on_import: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SendEmailRequest {
+    pub library_item_id: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UpdateMetadataApiRequest {
     pub hardcover_enabled: Option<bool>,
     pub hardcover_api_token: Option<String>,
@@ -1001,6 +1035,15 @@ pub trait ConfigApi: Send + Sync {
         &self,
         req: UpdateMetadataApiRequest,
     ) -> Result<MetadataConfigResponse, ApiError>;
+
+    /// Get email config. Password redacted in response.
+    async fn get_email(&self) -> Result<EmailConfigResponse, ApiError>;
+
+    /// Update email config.
+    async fn update_email(
+        &self,
+        req: UpdateEmailApiRequest,
+    ) -> Result<EmailConfigResponse, ApiError>;
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/livrarr-server/src/router.rs
+++ b/crates/livrarr-server/src/router.rs
@@ -94,6 +94,11 @@ pub fn build_router(state: AppState, ui_dir: std::path::PathBuf) -> Router {
             "/config/prowlarr",
             get(handlers::config::get_prowlarr).put(handlers::config::update_prowlarr),
         )
+        .route(
+            "/config/email",
+            get(handlers::config::get_email).put(handlers::config::update_email),
+        )
+        .route("/config/email/test", post(handlers::config::test_email))
         // Indexers (replaces /config/prowlarr — DEFERRED-001)
         .route(
             "/indexer",
@@ -199,6 +204,10 @@ pub fn build_router(state: AppState, ui_dir: std::path::PathBuf) -> Router {
         .route(
             "/workfile/{id}",
             get(handlers::workfile::get).delete(handlers::workfile::delete),
+        )
+        .route(
+            "/workfile/{id}/send-email",
+            post(handlers::workfile::send_email),
         )
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),

--- a/crates/livrarr-tagwrite/Cargo.toml
+++ b/crates/livrarr-tagwrite/Cargo.toml
@@ -10,5 +10,6 @@ tokio = { workspace = true }
 livrarr-domain = { workspace = true }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 quick-xml = "0.37"
+repub = { path = "/mnt/opt/repub" }
 mp4ameta = "0.13"
 id3 = "1.16"

--- a/crates/livrarr-tagwrite/src/lib.rs
+++ b/crates/livrarr-tagwrite/src/lib.rs
@@ -292,6 +292,9 @@ fn write_epub(
             } else if name == cover_entry_path && should_replace_cover {
                 // Skip old cover — we write the new one below.
                 continue;
+            } else if is_stale_livrarr_cover(&name, &cover_entry_path) {
+                // Skip leftover Livrarr-injected cover duplicates from prior runs.
+                continue;
             } else {
                 // Copy entry with original compression method.
                 if entry.size() > MAX_EPUB_ENTRY_BYTES as u64 {
@@ -351,6 +354,22 @@ fn write_epub(
                     message: format!("EPUB rename failed: {e}"),
                 }
             })?;
+
+            // Run repub EPUB repair pass (XML declarations, mimetype, identifiers,
+            // proprietary metadata stripping). Non-fatal — if repub fails, the
+            // file is still valid from our own tag writing above.
+            let language = metadata.language.as_deref().unwrap_or("en");
+            match repub::Repub::new()
+                .default_language(language)
+                .fix(path, path)
+            {
+                Ok(_report) => {}
+                Err(e) => {
+                    // Log but don't fail — our tag writing already succeeded.
+                    eprintln!("repub repair warning: {e}");
+                }
+            }
+
             Ok(())
         }
         Err(e) => {
@@ -358,6 +377,21 @@ fn write_epub(
             Err(e)
         }
     }
+}
+
+/// Returns true if this ZIP entry is a stale Livrarr-injected cover that should be removed.
+/// A Livrarr cover is stale when the real cover lives at a different path.
+fn is_stale_livrarr_cover(entry_name: &str, active_cover_path: &str) -> bool {
+    // Only applies when the active cover is NOT the Livrarr default path
+    let livrarr_paths: &[&str] = &[
+        EPUB_COVER_PATH,
+        "images/cover.jpg",
+        "OEBPS/images/cover.jpg",
+    ];
+    let is_livrarr_path = livrarr_paths
+        .iter()
+        .any(|p| entry_name.eq_ignore_ascii_case(p));
+    is_livrarr_path && !entry_name.eq_ignore_ascii_case(active_cover_path)
 }
 
 /// Parse container.xml with quick-xml to find the OPF path.
@@ -417,10 +451,16 @@ fn find_opf_path(archive: &mut zip::ZipArchive<std::fs::File>) -> Result<String,
 }
 
 /// Find the cover image path referenced in the OPF manifest.
+///
+/// Strategy:
+/// 1. Look for `<meta name="cover" content="item-id"/>` → find matching manifest `<item>` by id
+/// 2. Fallback: scan manifest for `<item>` with image media-type and id containing "cover"
+/// 3. Fallback: scan manifest for `<item>` with EPUB3 `properties="cover-image"`
 fn find_cover_path_in_opf(opf: &str) -> Option<String> {
     use quick_xml::events::Event;
     use quick_xml::Reader;
 
+    // Pass 1: find <meta name="cover" content="..."/>
     let mut reader = Reader::from_str(opf);
     let mut buf = Vec::new();
     let mut cover_id: Option<String> = None;
@@ -454,11 +494,12 @@ fn find_cover_path_in_opf(opf: &str) -> Option<String> {
         buf.clear();
     }
 
-    let cover_id = cover_id?;
-
-    // Second pass: find <item id="cover_id" href="path"/>
+    // Pass 2: scan manifest items — match by meta cover_id, or fallback heuristics
     let mut reader = Reader::from_str(opf);
     buf.clear();
+    let mut fallback_by_id: Option<String> = None;
+    let mut fallback_by_props: Option<String> = None;
+
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Empty(ref e)) | Ok(Event::Start(ref e))
@@ -466,6 +507,8 @@ fn find_cover_path_in_opf(opf: &str) -> Option<String> {
             {
                 let mut item_id = None;
                 let mut href = None;
+                let mut is_image = false;
+                let mut has_cover_prop = false;
                 for attr in e.attributes().flatten() {
                     match attr.key.local_name().as_ref() {
                         b"id" => {
@@ -474,11 +517,40 @@ fn find_cover_path_in_opf(opf: &str) -> Option<String> {
                         b"href" => {
                             href = attr.unescape_value().ok().map(|v| v.to_string());
                         }
+                        b"media-type" => {
+                            if let Ok(v) = attr.unescape_value() {
+                                is_image = v.starts_with("image/");
+                            }
+                        }
+                        b"properties" => {
+                            if let Ok(v) = attr.unescape_value() {
+                                has_cover_prop = v.split_whitespace().any(|p| p == "cover-image");
+                            }
+                        }
                         _ => {}
                     }
                 }
-                if item_id.as_deref() == Some(&cover_id) {
-                    return href;
+
+                // Exact match via <meta name="cover" content="id">
+                if let Some(ref cid) = cover_id {
+                    if item_id.as_deref() == Some(cid) {
+                        return href;
+                    }
+                }
+
+                // Heuristic: image item with "cover" in id
+                if is_image
+                    && fallback_by_id.is_none()
+                    && item_id
+                        .as_deref()
+                        .is_some_and(|id| id.to_lowercase().contains("cover"))
+                {
+                    fallback_by_id = href.clone();
+                }
+
+                // EPUB3: properties="cover-image"
+                if has_cover_prop && fallback_by_props.is_none() {
+                    fallback_by_props = href.clone();
                 }
             }
             Ok(Event::Eof) => break,
@@ -488,6 +560,41 @@ fn find_cover_path_in_opf(opf: &str) -> Option<String> {
         buf.clear();
     }
 
+    // Return best fallback
+    fallback_by_props.or(fallback_by_id)
+}
+
+/// Scan OPF events for a manifest `<item>` that looks like a cover image.
+/// Looks for items with id containing "cover" and an image media-type.
+fn find_cover_item_id_in_events(events: &[quick_xml::events::Event<'_>]) -> Option<String> {
+    use quick_xml::events::Event;
+    for event in events {
+        if let Event::Empty(e) | Event::Start(e) = event {
+            if e.local_name().as_ref() != b"item" {
+                continue;
+            }
+            let mut item_id = None;
+            let mut is_image = false;
+            let mut id_has_cover = false;
+            for attr in e.attributes().flatten() {
+                match attr.key.local_name().as_ref() {
+                    b"id" => {
+                        let val = attr.unescape_value().ok()?;
+                        id_has_cover = val.to_lowercase().contains("cover");
+                        item_id = Some(val.to_string());
+                    }
+                    b"media-type" => {
+                        let val = attr.unescape_value().ok()?;
+                        is_image = val.starts_with("image/");
+                    }
+                    _ => {}
+                }
+            }
+            if is_image && id_has_cover {
+                return item_id;
+            }
+        }
+    }
     None
 }
 
@@ -559,6 +666,7 @@ fn update_opf_metadata(
     ];
 
     // Collect preserved elements from inside metadata (non-managed dc:, non-calibre-meta).
+    let mut original_cover_id: Option<String> = None;
     let mut preserved_events: Vec<Event<'static>> = Vec::new();
     let mut i = meta_start + 1;
     while i < meta_end {
@@ -590,6 +698,17 @@ fn update_opf_metadata(
                             && a.unescape_value().ok().as_deref() == Some("cover")
                     })
                 };
+
+                if is_cover_meta {
+                    // Capture the original cover ID before stripping.
+                    for a in e.attributes().flatten() {
+                        if a.key.local_name().as_ref() == b"content" {
+                            if let Ok(v) = a.unescape_value() {
+                                original_cover_id = Some(v.to_string());
+                            }
+                        }
+                    }
+                }
 
                 if is_managed_dc || is_isbn_identifier || is_calibre_meta || is_cover_meta {
                     // Skip this element (and its content if it's a Start, not Empty).
@@ -716,12 +835,20 @@ fn update_opf_metadata(
         }
     }
 
-    // Cover reference in metadata — only when a cover is actually being embedded.
-    if add_cover_manifest_item {
+    // Cover reference in metadata — always ensure one exists.
+    // Priority: new Livrarr cover > original meta > scan manifest for cover-like item.
+    let cover_content_id = if add_cover_manifest_item {
+        Some(LIVRARR_COVER_ID.to_string())
+    } else if original_cover_id.is_some() {
+        original_cover_id
+    } else {
+        find_cover_item_id_in_events(&events)
+    };
+    if let Some(ref cid) = cover_content_id {
         new_meta_events.push(Event::Text(nl(indent).into_owned()));
         let mut elem = BytesStart::new("meta");
         elem.push_attribute(("name", "cover"));
-        elem.push_attribute(("content", LIVRARR_COVER_ID));
+        elem.push_attribute(("content", cid.as_str()));
         new_meta_events.push(Event::Empty(elem.into_owned()));
     }
 
@@ -763,7 +890,34 @@ fn update_opf_metadata(
             result_events.extend(events[meta_end..].iter().cloned());
         }
     } else {
-        result_events.extend(events[meta_end..].iter().cloned());
+        // Copy remaining events, but strip any stale livrarr-cover-image manifest items.
+        let mut skip_depth: usize = 0;
+        for event in &events[meta_end..] {
+            if skip_depth > 0 {
+                if matches!(event, Event::Start(_)) {
+                    skip_depth += 1;
+                } else if matches!(event, Event::End(_)) {
+                    skip_depth -= 1;
+                }
+                continue;
+            }
+            let is_stale_item = match event {
+                Event::Empty(e) | Event::Start(e) if e.local_name().as_ref() == b"item" => {
+                    e.attributes().flatten().any(|a| {
+                        a.key.local_name().as_ref() == b"id"
+                            && a.unescape_value().ok().as_deref() == Some(LIVRARR_COVER_ID)
+                    })
+                }
+                _ => false,
+            };
+            if is_stale_item {
+                if matches!(event, Event::Start(_)) {
+                    skip_depth = 1;
+                }
+                continue;
+            }
+            result_events.push(event.clone());
+        }
     }
 
     // Serialize.

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -49,6 +49,8 @@ import type {
   ProwlarrConfigResponse,
   ProwlarrImportRequest,
   ProwlarrImportResponse,
+  EmailConfigResponse,
+  UpdateEmailConfigRequest,
   MetadataConfigResponse,
   UpdateMetadataConfigRequest,
   HealthCheckResult,
@@ -335,6 +337,19 @@ export const importDownloadClientsFromProwlarr = (req: ProwlarrImportRequest) =>
   apiFetch<ProwlarrImportResponse>("/downloadclient/import/prowlarr", {
     method: "POST",
     body: JSON.stringify(req),
+  });
+export const getEmailConfig = () =>
+  apiFetch<EmailConfigResponse>("/config/email");
+export const updateEmailConfig = (req: UpdateEmailConfigRequest) =>
+  apiFetch<EmailConfigResponse>("/config/email", {
+    method: "PUT",
+    body: JSON.stringify(req),
+  });
+export const testEmailConfig = () =>
+  apiFetch<{ success: boolean }>("/config/email/test", { method: "POST" });
+export const sendFileEmail = (fileId: number) =>
+  apiFetch<{ success: boolean }>(`/workfile/${fileId}/send-email`, {
+    method: "POST",
   });
 export const getMetadataConfig = () =>
   apiFetch<MetadataConfigResponse>("/config/metadata");

--- a/frontend/src/components/GuidedTour/tourSteps.ts
+++ b/frontend/src/components/GuidedTour/tourSteps.ts
@@ -113,6 +113,14 @@ export const TOUR_STEPS: Step[] = [
     data: { route: "/settings/mediamanagement" },
   },
   {
+    target: "[data-tour='email-kindle-section']",
+    content:
+      "Send books directly to your Kindle or eReader via email. Pick a provider preset (Gmail, Outlook) or enter custom SMTP settings. You'll need your Kindle email address (find it at amazon.com/myk → Devices) and must add the From address to your Approved Personal Document Email List (amazon.com/myk → Preferences → Personal Document Settings). Enable 'Send on import' to automatically deliver new books.",
+    placement: "top",
+    skipBeacon: true,
+    data: { route: "/settings/mediamanagement" },
+  },
+  {
     target: "body",
     content:
       "You're all set! Configure each section at your own pace. You can always revisit these settings from the sidebar. Happy reading!",

--- a/frontend/src/pages/settings/media-management/MediaManagementPage.tsx
+++ b/frontend/src/pages/settings/media-management/MediaManagementPage.tsx
@@ -15,6 +15,10 @@ import {
   HardDrive,
   BookOpen,
   Headphones,
+  Mail,
+  CheckCircle2,
+  XCircle,
+  Loader2,
 } from "lucide-react";
 import {
   DndContext,
@@ -519,6 +523,9 @@ export default function MediaManagementPage() {
           </section>
         )}
 
+        {/* ── Email / Send to Kindle (admin only) ── */}
+        {isAdmin && <EmailConfigSection />}
+
         {/* ── Naming (read-only) ── */}
         <section className="rounded-lg border border-border bg-zinc-900/50 opacity-60" title="Coming Soon">
           <div className="flex items-center gap-2 border-b border-border bg-zinc-800/60 px-5 py-3 rounded-t-lg">
@@ -856,5 +863,277 @@ function SortableFormatItem({
       <span className="flex-1 text-sm text-zinc-200 font-mono">.{id}</span>
       <span className="text-xs text-muted">#{rank}</span>
     </div>
+  );
+}
+
+// ── Email / Send to Kindle Config (MOCK) ──
+
+const SMTP_PRESETS: Record<string, { host: string; port: number; encryption: string }> = {
+  gmail: { host: "smtp.gmail.com", port: 587, encryption: "starttls" },
+  outlook: { host: "smtp-mail.outlook.com", port: 587, encryption: "starttls" },
+  custom: { host: "", port: 587, encryption: "starttls" },
+};
+
+function detectPreset(host: string): string {
+  if (host === "smtp.gmail.com") return "gmail";
+  if (host === "smtp-mail.outlook.com") return "outlook";
+  return "custom";
+}
+
+function EmailConfigSection() {
+  const qc = useQueryClient();
+  const emailConfigQ = useQuery({
+    queryKey: ["emailConfig"],
+    queryFn: api.getEmailConfig,
+  });
+
+  const [preset, setPreset] = useState<string | null>(null);
+  const [host, setHost] = useState<string | null>(null);
+  const [port, setPort] = useState<number | null>(null);
+  const [encryption, setEncryption] = useState<string | null>(null);
+  const [username, setUsername] = useState<string | null>(null);
+  const [password, setPassword] = useState("");
+  const [fromAddress, setFromAddress] = useState<string | null>(null);
+  const [recipientEmail, setRecipientEmail] = useState<string | null>(null);
+  const [sendOnImport, setSendOnImport] = useState<boolean | null>(null);
+  const [testState, setTestState] = useState<"idle" | "loading" | "success" | "fail">("idle");
+
+  // Derive current values from local overrides or server data
+  const cfg = emailConfigQ.data;
+  const curHost = host ?? cfg?.smtpHost ?? "smtp.gmail.com";
+  const curPort = port ?? cfg?.smtpPort ?? 587;
+  const curEncryption = encryption ?? cfg?.encryption ?? "starttls";
+  const curUsername = username ?? cfg?.username ?? "";
+  const curFromAddress = fromAddress ?? cfg?.fromAddress ?? "";
+  const curRecipientEmail = recipientEmail ?? cfg?.recipientEmail ?? "";
+  const curSendOnImport = sendOnImport ?? cfg?.sendOnImport ?? false;
+  const curPreset = preset ?? detectPreset(curHost);
+
+  const updateEmail = useMutation({
+    mutationFn: api.updateEmailConfig,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["emailConfig"] });
+      // Reset local overrides so we read from server
+      setHost(null);
+      setPort(null);
+      setEncryption(null);
+      setUsername(null);
+      setPassword("");
+      setFromAddress(null);
+      setRecipientEmail(null);
+      setSendOnImport(null);
+      setPreset(null);
+      toast.success("Email configuration saved");
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  const applyPreset = (key: string) => {
+    setPreset(key);
+    const p = SMTP_PRESETS[key];
+    if (p) {
+      setHost(p.host || curHost);
+      setPort(p.port);
+      setEncryption(p.encryption);
+    }
+    if (key === "gmail" && !curUsername) {
+      setUsername("you@gmail.com");
+      if (!curFromAddress) setFromAddress("you@gmail.com");
+    } else if (key === "outlook" && !curUsername) {
+      setUsername("you@outlook.com");
+      if (!curFromAddress) setFromAddress("you@outlook.com");
+    }
+  };
+
+  const handleSave = () => {
+    updateEmail.mutate({
+      smtpHost: curHost,
+      smtpPort: curPort,
+      encryption: curEncryption,
+      username: curUsername || null,
+      ...(password ? { password } : {}),
+      fromAddress: curFromAddress || null,
+      recipientEmail: curRecipientEmail || null,
+      sendOnImport: curSendOnImport,
+      enabled: true,
+    });
+  };
+
+  const handleTest = async () => {
+    setTestState("loading");
+    try {
+      await api.testEmailConfig();
+      setTestState("success");
+      toast.success("Test email sent");
+    } catch (e) {
+      setTestState("fail");
+      toast.error(e instanceof Error ? e.message : "Test email failed");
+    }
+  };
+
+  if (emailConfigQ.isLoading) return null;
+
+  return (
+    <section data-tour="email-kindle-section" className="rounded-lg border border-border bg-zinc-900/50">
+      <div className="flex items-center gap-2 border-b border-border bg-zinc-800/60 px-5 py-3 rounded-t-lg">
+        <Mail size={18} className="text-muted" />
+        <h2 className="text-base font-semibold text-zinc-100">
+          Email / Send to Kindle
+        </h2>
+        <HelpTip text="Send ebooks to your Kindle or eReader via email. Configure your SMTP server and recipient email address. You must add the 'From' address to your Amazon Approved Personal Document Email List." />
+      </div>
+      <div className="p-5">
+        <div className="max-w-xl space-y-4">
+          {/* Provider preset */}
+          <div>
+            <label className="block text-xs text-muted mb-1">Provider</label>
+            <select
+              value={curPreset}
+              onChange={(e) => applyPreset(e.target.value)}
+              className="w-full rounded border border-border bg-zinc-900 px-3 py-2 text-sm text-zinc-100 focus:border-brand focus:outline-none"
+            >
+              <option value="custom">Custom SMTP</option>
+              <option value="gmail">Gmail</option>
+              <option value="outlook">Outlook</option>
+            </select>
+          </div>
+
+          {/* SMTP Host + Port */}
+          <div className="grid grid-cols-3 gap-3">
+            <div className="col-span-2">
+              <label className="block text-xs text-muted mb-1">SMTP Host</label>
+              <input
+                type="text"
+                value={curHost}
+                onChange={(e) => setHost(e.target.value)}
+                placeholder="smtp.example.com"
+                className="w-full rounded border border-border bg-zinc-900 px-3 py-2 text-sm text-zinc-100 focus:border-brand focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-muted mb-1">Port</label>
+              <input
+                type="number"
+                value={curPort}
+                onChange={(e) => setPort(Number(e.target.value))}
+                className="w-full rounded border border-border bg-zinc-900 px-3 py-2 text-sm text-zinc-100 focus:border-brand focus:outline-none"
+              />
+            </div>
+          </div>
+
+          {/* Encryption */}
+          <div>
+            <label className="block text-xs text-muted mb-1">Encryption</label>
+            <select
+              value={curEncryption}
+              onChange={(e) => setEncryption(e.target.value)}
+              className="w-full rounded border border-border bg-zinc-900 px-3 py-2 text-sm text-zinc-100 focus:border-brand focus:outline-none"
+            >
+              <option value="none">None</option>
+              <option value="starttls">STARTTLS</option>
+              <option value="ssl">SSL/TLS</option>
+            </select>
+          </div>
+
+          {/* Username + Password */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs text-muted mb-1">Username</label>
+              <input
+                type="text"
+                value={curUsername}
+                onChange={(e) => setUsername(e.target.value)}
+                placeholder="user@example.com"
+                className="w-full rounded border border-border bg-zinc-900 px-3 py-2 text-sm text-zinc-100 focus:border-brand focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="flex items-center gap-1 text-xs text-muted mb-1">
+                Password
+                {curPreset === "gmail" ? (
+                  <HelpTip text="Gmail requires an App Password, not your account password. Go to myaccount.google.com → Security → 2-Step Verification → App Passwords. Generate a new app password for 'Mail' and paste it here." />
+                ) : curPreset === "outlook" ? (
+                  <HelpTip text="If you have 2FA enabled, go to account.microsoft.com → Security → Advanced security options → App passwords. Generate a new app password and paste it here." />
+                ) : null}
+              </label>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder={cfg?.passwordSet ? "••••••••" : ""}
+                className="w-full rounded border border-border bg-zinc-900 px-3 py-2 text-sm text-zinc-100 focus:border-brand focus:outline-none"
+              />
+            </div>
+          </div>
+
+          {/* From Address */}
+          <div>
+            <label className="block text-xs text-muted mb-1">From Address</label>
+            <input
+              type="email"
+              value={curFromAddress}
+              onChange={(e) => setFromAddress(e.target.value)}
+              placeholder="livrarr@example.com"
+              className="w-full rounded border border-border bg-zinc-900 px-3 py-2 text-sm text-zinc-100 focus:border-brand focus:outline-none"
+            />
+            <p className="mt-1 text-xs text-muted inline-flex items-center gap-1">
+              Must be on your Kindle Approved Email List
+              <HelpTip text="To add this address: 1) Go to amazon.com/myk → Preferences → Personal Document Settings. 2) Scroll to 'Approved Personal Document E-mail List'. 3) Click 'Add a new approved e-mail address'. 4) Enter the From Address above and click 'Add Address'. Without this, Amazon will silently reject emails from Livrarr." />
+            </p>
+          </div>
+
+          {/* Recipient Email */}
+          <div>
+            <label className="block text-xs text-muted mb-1">Kindle Email</label>
+            <input
+              type="email"
+              value={curRecipientEmail}
+              onChange={(e) => setRecipientEmail(e.target.value)}
+              placeholder="yourname@kindle.com"
+              className="w-full rounded border border-border bg-zinc-900 px-3 py-2 text-sm text-zinc-100 focus:border-brand focus:outline-none"
+            />
+          </div>
+
+          {/* Auto-send on import */}
+          <label className="flex items-center gap-3 text-sm text-zinc-200 cursor-pointer group">
+            <input
+              type="checkbox"
+              checked={curSendOnImport}
+              onChange={(e) => setSendOnImport(e.target.checked)}
+              className="rounded border-border"
+            />
+            <span>Send to Kindle automatically on import</span>
+            <HelpTip text="Automatically emails EPUB and PDF files to your Kindle when imported. Other formats (MOBI, AZW3, M4B, etc.) are skipped. If the send fails, you'll see a notification — the import itself is not affected." />
+          </label>
+
+          {/* Actions */}
+          <div className="flex items-center gap-3 pt-2">
+            <button
+              onClick={handleSave}
+              disabled={updateEmail.isPending}
+              className="rounded bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand-hover disabled:opacity-50"
+            >
+              {updateEmail.isPending ? "Saving..." : "Save"}
+            </button>
+            <button
+              onClick={handleTest}
+              disabled={testState === "loading" || !curHost || !curRecipientEmail}
+              className="inline-flex items-center gap-1.5 rounded border border-border px-3 py-2 text-sm text-zinc-300 hover:text-zinc-100 hover:border-zinc-500 disabled:opacity-50"
+            >
+              {testState === "loading" ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : testState === "success" ? (
+                <CheckCircle2 size={14} className="text-green-400" />
+              ) : testState === "fail" ? (
+                <XCircle size={14} className="text-red-400" />
+              ) : (
+                <Mail size={14} />
+              )}
+              Send Test Email
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
   );
 }

--- a/frontend/src/pages/work-detail/WorkDetailPage.tsx
+++ b/frontend/src/pages/work-detail/WorkDetailPage.tsx
@@ -19,6 +19,7 @@ import {
   Clock,
   ChevronDown,
   ChevronRight,
+  Mail,
 } from "lucide-react";
 import {
   getWork,
@@ -31,6 +32,7 @@ import {
   getHistory,
   deleteLibraryFile,
   getMediaManagementConfig,
+  sendFileEmail,
 } from "@/api";
 import { PageToolbar } from "@/components/Page/PageToolbar";
 import { PageContent } from "@/components/Page/PageContent";
@@ -289,9 +291,23 @@ function TabTrigger({
 
 // --- Library Files Tab ---
 
+// Formats Amazon accepts via Send to Kindle email
+const KINDLE_ACCEPTED_FORMATS = new Set([
+  "epub", "pdf", "docx", "doc", "rtf", "htm", "html", "txt",
+]);
+
+const MAX_EMAIL_SIZE = 50 * 1024 * 1024; // 50 MB
+
+function getFileExtension(path: string): string {
+  const dot = path.lastIndexOf(".");
+  return dot >= 0 ? path.slice(dot + 1).toLowerCase() : "";
+}
+
 function LibraryFilesTab({ work }: { work: WorkDetailResponse }) {
   const queryClient = useQueryClient();
   const [confirmDelete, setConfirmDelete] = useState<number | null>(null);
+  const [sendingId, setSendingId] = useState<number | null>(null);
+  const [sentIds, setSentIds] = useState<Set<number>>(new Set());
 
   const deleteFileMutation = useMutation({
     mutationFn: (fileId: number) => deleteLibraryFile(fileId),
@@ -302,6 +318,24 @@ function LibraryFilesTab({ work }: { work: WorkDetailResponse }) {
     },
     onError: () => toast.error("Failed to delete file"),
   });
+
+  const sendEmailMutation = useMutation({
+    mutationFn: sendFileEmail,
+    onSuccess: (_data, itemId) => {
+      setSendingId(null);
+      setSentIds((prev) => new Set(prev).add(itemId));
+      toast.success("Sent to Kindle");
+    },
+    onError: (e: Error) => {
+      setSendingId(null);
+      toast.error(e.message || "Failed to send email");
+    },
+  });
+
+  const handleSendEmail = (itemId: number) => {
+    setSendingId(itemId);
+    sendEmailMutation.mutate(itemId);
+  };
 
   if (work.libraryItems.length === 0) {
     return (
@@ -331,45 +365,73 @@ function LibraryFilesTab({ work }: { work: WorkDetailResponse }) {
               <th className="px-3 py-2 text-left text-xs font-medium uppercase text-muted">
                 Imported
               </th>
-              <th className="w-10 px-3 py-2" />
+              <th className="w-20 px-3 py-2" />
             </tr>
           </thead>
           <tbody className="divide-y divide-border">
-            {work.libraryItems.map((item) => (
-              <tr key={item.id} className="hover:bg-zinc-800/50">
-                <td
-                  className="max-w-md truncate px-3 py-2 font-mono text-xs text-zinc-300"
-                  title={item.path}
-                >
-                  {item.path}
-                </td>
-                <td className="px-3 py-2">
-                  <div className="inline-flex items-center gap-1 text-zinc-400">
-                    {item.mediaType === "ebook" ? (
-                      <Book size={14} />
-                    ) : (
-                      <Headphones size={14} />
-                    )}
-                    <span className="text-xs capitalize">{item.mediaType}</span>
-                  </div>
-                </td>
-                <td className="px-3 py-2 text-right text-muted">
-                  {formatBytes(item.fileSize)}
-                </td>
-                <td className="px-3 py-2 text-muted">
-                  {formatRelativeDate(item.importedAt)}
-                </td>
-                <td className="px-3 py-2">
-                  <button
-                    onClick={() => setConfirmDelete(item.id)}
-                    className="rounded p-1 text-muted hover:text-red-400"
-                    title="Delete file"
+            {work.libraryItems.map((item) => {
+              const ext = getFileExtension(item.path);
+              const canSend = KINDLE_ACCEPTED_FORMATS.has(ext);
+              const tooLarge = item.fileSize > MAX_EMAIL_SIZE;
+              const isSending = sendingId === item.id;
+              const wasSent = sentIds.has(item.id);
+
+              return (
+                <tr key={item.id} className="hover:bg-zinc-800/50">
+                  <td
+                    className="max-w-md truncate px-3 py-2 font-mono text-xs text-zinc-300"
+                    title={item.path}
                   >
-                    <Trash2 size={14} />
-                  </button>
-                </td>
-              </tr>
-            ))}
+                    {item.path}
+                  </td>
+                  <td className="px-3 py-2">
+                    <div className="inline-flex items-center gap-1 text-zinc-400">
+                      {item.mediaType === "ebook" ? (
+                        <Book size={14} />
+                      ) : (
+                        <Headphones size={14} />
+                      )}
+                      <span className="text-xs capitalize">{item.mediaType}</span>
+                    </div>
+                  </td>
+                  <td className="px-3 py-2 text-right text-muted">
+                    {formatBytes(item.fileSize)}
+                  </td>
+                  <td className="px-3 py-2 text-muted">
+                    {formatRelativeDate(item.importedAt)}
+                  </td>
+                  <td className="px-3 py-2 flex items-center justify-end gap-1">
+                    {canSend && (
+                      <button
+                        onClick={() => handleSendEmail(item.id)}
+                        disabled={isSending || tooLarge}
+                        className={`rounded p-1 hover:text-brand disabled:opacity-40 ${tooLarge ? "disabled:cursor-not-allowed text-muted" : isSending ? "cursor-wait text-brand" : wasSent ? "text-green-400" : "text-muted"}`}
+                        title={
+                          tooLarge
+                            ? `File too large (${formatBytes(item.fileSize)}). Amazon limit is 50 MB.`
+                            : wasSent
+                              ? "Sent to Kindle"
+                              : "Send to Kindle"
+                        }
+                      >
+                        {isSending ? (
+                          <Loader2 size={14} className="animate-spin text-brand" />
+                        ) : (
+                          <Mail size={14} className={wasSent ? "text-green-400" : ""} />
+                        )}
+                      </button>
+                    )}
+                    <button
+                      onClick={() => setConfirmDelete(item.id)}
+                      className="rounded p-1 text-muted hover:text-red-400"
+                      title="Delete file"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -501,6 +501,30 @@ export interface ProwlarrImportResponse {
   errors: string[];
 }
 
+export interface EmailConfigResponse {
+  enabled: boolean;
+  smtpHost: string;
+  smtpPort: number;
+  encryption: string;
+  username: string | null;
+  passwordSet: boolean;
+  fromAddress: string | null;
+  recipientEmail: string | null;
+  sendOnImport: boolean;
+}
+
+export interface UpdateEmailConfigRequest {
+  enabled?: boolean;
+  smtpHost?: string;
+  smtpPort?: number;
+  encryption?: string;
+  username?: string | null;
+  password?: string | null;
+  fromAddress?: string | null;
+  recipientEmail?: string | null;
+  sendOnImport?: boolean;
+}
+
 export interface MetadataConfigResponse {
   hardcoverEnabled: boolean;
   hardcoverApiToken: string | null;


### PR DESCRIPTION
## Summary
- SMTP email integration with Gmail/Outlook presets, test email, per-file send on Library Files, auto-send on import
- Integrated repub crate for EPUB repair (XML declarations, mimetype, metadata, proprietary stripping)
- Enrichment defaults dc:language from metadata config; bulk refresh now retags files
- Cover handling heuristics for EPUBs without `<meta name="cover">`
- Guided tour updated with Kindle setup step

## Test plan
- [x] Configure Gmail SMTP, send test email
- [x] Send EPUB to Kindle — delivered successfully
- [x] Verify EPUB metadata pristine after enrichment + repub
- [x] Verify bulk refresh retags library files
- [x] cargo fmt/clippy/build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)