### PR TITLE
File playback: OPDS catalog, download streaming, playback progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,6 +1686,7 @@ dependencies = [
  "chrono",
  "clap",
  "dashmap",
+ "data-encoding",
  "futures",
  "getrandom 0.2.17",
  "hex",

--- a/crates/livrarr-db/migrations/018_playback_progress.sql
+++ b/crates/livrarr-db/migrations/018_playback_progress.sql
@@ -1,0 +1,13 @@
+-- Playback progress tracking for ebook reading and audiobook listening.
+
+CREATE TABLE playback_progress (
+    id INTEGER PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    library_item_id INTEGER NOT NULL REFERENCES library_items(id),
+    position TEXT NOT NULL,
+    progress_pct REAL NOT NULL DEFAULT 0.0,
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE(user_id, library_item_id)
+);
+
+CREATE INDEX idx_playback_progress_user ON playback_progress(user_id);

--- a/crates/livrarr-db/src/lib.rs
+++ b/crates/livrarr-db/src/lib.rs
@@ -4,8 +4,9 @@ pub use livrarr_domain::{
     Author, AuthorId, DbError, DownloadClient, DownloadClientId, DownloadClientImplementation,
     EnrichmentStatus, EventType, Grab, GrabId, GrabStatus, HistoryEvent, HistoryId, Indexer,
     IndexerConfig, IndexerId, IndexerRssState, LibraryItem, LibraryItemId, LlmProvider, MediaType,
-    NarrationType, Notification, NotificationId, NotificationType, RemotePathMapping,
-    RemotePathMappingId, RootFolder, RootFolderId, Session, User, UserId, UserRole, Work, WorkId,
+    NarrationType, Notification, NotificationId, NotificationType, PlaybackProgress,
+    RemotePathMapping, RemotePathMappingId, RootFolder, RootFolderId, Session, User, UserId,
+    UserRole, Work, WorkId,
 };
 
 pub mod pool;
@@ -20,6 +21,7 @@ mod sqlite_history;
 mod sqlite_indexer;
 mod sqlite_library_item;
 mod sqlite_notification;
+mod sqlite_playback_progress;
 mod sqlite_remote_path_mapping;
 mod sqlite_root_folder;
 mod sqlite_session;
@@ -1055,6 +1057,26 @@ pub trait AuthorBibliographyDb: Send + Sync {
         author_id: i64,
         entries: &[BibliographyEntry],
     ) -> Result<AuthorBibliography, DbError>;
+}
+
+/// Playback progress data access.
+#[trait_variant::make(Send)]
+pub trait PlaybackProgressDb: Send + Sync {
+    /// Get playback progress for a user + library item.
+    async fn get_progress(
+        &self,
+        user_id: UserId,
+        library_item_id: LibraryItemId,
+    ) -> Result<Option<PlaybackProgress>, DbError>;
+
+    /// Insert or update playback progress.
+    async fn upsert_progress(
+        &self,
+        user_id: UserId,
+        library_item_id: LibraryItemId,
+        position: &str,
+        progress_pct: f64,
+    ) -> Result<(), DbError>;
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/livrarr-db/src/sqlite_playback_progress.rs
+++ b/crates/livrarr-db/src/sqlite_playback_progress.rs
@@ -1,0 +1,81 @@
+use sqlx::Row;
+
+use crate::sqlite::SqliteDb;
+use crate::sqlite_common::{map_db_err, parse_dt};
+use crate::{DbError, LibraryItemId, PlaybackProgress, PlaybackProgressDb, UserId};
+
+fn row_to_progress(row: sqlx::sqlite::SqliteRow) -> Result<PlaybackProgress, DbError> {
+    Ok(PlaybackProgress {
+        id: row
+            .try_get::<i64, _>("id")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
+        user_id: row
+            .try_get::<i64, _>("user_id")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
+        library_item_id: row
+            .try_get::<i64, _>("library_item_id")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
+        position: row
+            .try_get("position")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
+        progress_pct: row
+            .try_get("progress_pct")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
+        updated_at: parse_dt(
+            &row.try_get::<String, _>("updated_at")
+                .map_err(|e| DbError::Io(Box::new(e)))?,
+        )?,
+    })
+}
+
+impl PlaybackProgressDb for SqliteDb {
+    async fn get_progress(
+        &self,
+        user_id: UserId,
+        library_item_id: LibraryItemId,
+    ) -> Result<Option<PlaybackProgress>, DbError> {
+        let row = sqlx::query(
+            "SELECT id, user_id, library_item_id, position, progress_pct, updated_at
+             FROM playback_progress
+             WHERE user_id = ? AND library_item_id = ?",
+        )
+        .bind(user_id)
+        .bind(library_item_id)
+        .fetch_optional(self.pool())
+        .await
+        .map_err(map_db_err)?;
+
+        match row {
+            Some(r) => Ok(Some(row_to_progress(r)?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn upsert_progress(
+        &self,
+        user_id: UserId,
+        library_item_id: LibraryItemId,
+        position: &str,
+        progress_pct: f64,
+    ) -> Result<(), DbError> {
+        let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+        sqlx::query(
+            "INSERT INTO playback_progress (user_id, library_item_id, position, progress_pct, updated_at)
+             VALUES (?, ?, ?, ?, ?)
+             ON CONFLICT(user_id, library_item_id)
+             DO UPDATE SET position = excluded.position,
+                           progress_pct = excluded.progress_pct,
+                           updated_at = excluded.updated_at",
+        )
+        .bind(user_id)
+        .bind(library_item_id)
+        .bind(position)
+        .bind(progress_pct)
+        .bind(&now)
+        .execute(self.pool())
+        .await
+        .map_err(map_db_err)?;
+
+        Ok(())
+    }
+}

--- a/crates/livrarr-domain/src/lib.rs
+++ b/crates/livrarr-domain/src/lib.rs
@@ -400,6 +400,19 @@ pub struct LibraryItem {
     pub imported_at: DateTime<Utc>,
 }
 
+/// Playback progress — reading/listening position for a library item.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlaybackProgress {
+    pub id: i64,
+    pub user_id: UserId,
+    pub library_item_id: LibraryItemId,
+    /// CFI string (EPUB), page number (PDF), or seconds as float (audio).
+    pub position: String,
+    /// 0.0 to 1.0.
+    pub progress_pct: f64,
+    pub updated_at: DateTime<Utc>,
+}
+
 /// Root folder.
 ///
 /// Satisfies: IMPORT-001, IMPORT-002, IMPORT-003

--- a/crates/livrarr-server/Cargo.toml
+++ b/crates/livrarr-server/Cargo.toml
@@ -53,6 +53,7 @@ regex = "1"
 rbook = "0.4"
 mp4ameta = "0.13"
 id3 = "1.16"
+data-encoding = "2.10.0"
 
 [dev-dependencies]
 livrarr-db = { workspace = true, features = ["test-helpers"] }

--- a/crates/livrarr-server/src/handlers/mod.rs
+++ b/crates/livrarr-server/src/handlers/mod.rs
@@ -12,6 +12,7 @@ pub mod indexer;
 pub mod manual_import;
 pub mod mediacover;
 pub mod notification;
+pub mod opds;
 pub mod profile;
 pub mod queue;
 pub mod release;

--- a/crates/livrarr-server/src/handlers/opds.rs
+++ b/crates/livrarr-server/src/handlers/opds.rs
@@ -1,0 +1,543 @@
+use axum::extract::{Path, Query, State};
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+
+use crate::state::AppState;
+use livrarr_db::{AuthorDb, LibraryItemDb, UserDb, WorkDb};
+use livrarr_domain::{LibraryItem, User, Work};
+
+// ---------------------------------------------------------------------------
+// OPDS Basic Auth
+// ---------------------------------------------------------------------------
+
+/// Extract user from HTTP Basic Auth (username + API key as password).
+/// Returns 401 with WWW-Authenticate header on failure.
+async fn basic_auth(state: &AppState, headers: &HeaderMap) -> Result<User, Response> {
+    let unauthorized = || {
+        (
+            StatusCode::UNAUTHORIZED,
+            [(header::WWW_AUTHENTICATE, "Basic realm=\"Livrarr OPDS\"")],
+            "Unauthorized",
+        )
+            .into_response()
+    };
+
+    let auth_header = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .ok_or_else(unauthorized)?;
+
+    if !auth_header.starts_with("Basic ") {
+        return Err(unauthorized());
+    }
+
+    use data_encoding::BASE64;
+    let decoded = BASE64
+        .decode(auth_header[6..].trim().as_bytes())
+        .map_err(|_| unauthorized())?;
+    let creds = String::from_utf8(decoded).map_err(|_| unauthorized())?;
+    let (username, api_key) = creds.split_once(':').ok_or_else(unauthorized)?;
+
+    // Look up user by username, then verify API key via SHA-256 hash comparison.
+    let user = state
+        .db
+        .get_user_by_username(username)
+        .await
+        .map_err(|_| unauthorized())?;
+
+    // Hash the provided API key and compare with stored hash.
+    use crate::auth_crypto::{AuthCryptoService, RealAuthCrypto};
+    let crypto = RealAuthCrypto;
+    let key_hash = crypto
+        .hash_token(api_key)
+        .await
+        .map_err(|_| unauthorized())?;
+
+    let stored_user = state
+        .db
+        .get_user_by_api_key_hash(&key_hash)
+        .await
+        .map_err(|_| unauthorized())?;
+
+    // Verify it's the same user.
+    if stored_user.id != user.id {
+        return Err(unauthorized());
+    }
+
+    Ok(user)
+}
+
+// ---------------------------------------------------------------------------
+// XML helpers
+// ---------------------------------------------------------------------------
+
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+fn mime_for_ext(ext: &str) -> &'static str {
+    match ext {
+        "epub" => "application/epub+zip",
+        "pdf" => "application/pdf",
+        "mobi" => "application/x-mobipocket-ebook",
+        "azw3" => "application/x-mobi8-ebook",
+        "m4b" | "m4a" => "audio/mp4",
+        "mp3" => "audio/mpeg",
+        "flac" => "audio/flac",
+        "ogg" => "audio/ogg",
+        _ => "application/octet-stream",
+    }
+}
+
+const ATOM_NS: &str = "http://www.w3.org/2005/Atom";
+const DC_NS: &str = "http://purl.org/dc/terms/";
+const OPDS_NS: &str = "http://opds-spec.org/2010/catalog";
+const PAGE_SIZE: usize = 20;
+
+fn xml_response(body: String) -> Response {
+    (
+        StatusCode::OK,
+        [(
+            header::CONTENT_TYPE,
+            "application/atom+xml;profile=opds-catalog;charset=utf-8",
+        )],
+        body,
+    )
+        .into_response()
+}
+
+fn feed_header(id: &str, title: &str, self_href: &str) -> String {
+    let now = chrono::Utc::now().to_rfc3339();
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="{ATOM_NS}" xmlns:dc="{DC_NS}" xmlns:opds="{OPDS_NS}">
+  <id>{id}</id>
+  <title>{title}</title>
+  <updated>{now}</updated>
+  <link rel="self" href="{self_href}" type="application/atom+xml;profile=opds-catalog"/>
+  <link rel="start" href="/opds/" type="application/atom+xml;profile=opds-catalog"/>
+  <link rel="search" href="/opds/osd" type="application/opensearchdescription+xml"/>
+"#
+    )
+}
+
+fn nav_entry(title: &str, href: &str, content: &str) -> String {
+    let id = xml_escape(href);
+    let now = chrono::Utc::now().to_rfc3339();
+    format!(
+        r#"  <entry>
+    <title>{title}</title>
+    <id>{id}</id>
+    <updated>{now}</updated>
+    <content type="text">{content}</content>
+    <link rel="subsection" href="{href}" type="application/atom+xml;profile=opds-catalog"/>
+  </entry>
+"#,
+        title = xml_escape(title),
+        content = xml_escape(content),
+    )
+}
+
+fn work_entry(work: &Work, items: &[LibraryItem]) -> String {
+    let id = format!("urn:livrarr:work:{}", work.id);
+    let title = xml_escape(&work.title);
+    let author = xml_escape(&work.author_name);
+    let updated = work.added_at.to_rfc3339();
+    let desc = work
+        .description
+        .as_deref()
+        .map(|d| xml_escape(d))
+        .unwrap_or_default();
+    let lang = work
+        .language
+        .as_deref()
+        .map(|l| format!("  <dc:language>{}</dc:language>\n", xml_escape(l)))
+        .unwrap_or_default();
+
+    let cover_link = format!(
+        r#"  <link rel="http://opds-spec.org/image" href="/opds/cover/{}" type="image/jpeg"/>"#,
+        work.id
+    );
+
+    let acq_links: String = items
+        .iter()
+        .map(|item| {
+            let ext = item
+                .path
+                .rsplit('.')
+                .next()
+                .unwrap_or("")
+                .to_lowercase();
+            let mime = mime_for_ext(&ext);
+            format!(
+                r#"  <link rel="http://opds-spec.org/acquisition" href="/opds/download/{}" type="{}" length="{}"/>"#,
+                item.id, mime, item.file_size
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        r#"  <entry>
+    <title>{title}</title>
+    <id>{id}</id>
+    <updated>{updated}</updated>
+    <author><name>{author}</name></author>
+    <content type="text">{desc}</content>
+{lang}{cover_link}
+{acq_links}
+  </entry>
+"#
+    )
+}
+
+fn pagination_links(base_href: &str, page: usize, total: usize) -> String {
+    let mut links = String::new();
+    if page > 1 {
+        let sep = if base_href.contains('?') { "&" } else { "?" };
+        links.push_str(&format!(
+            r#"  <link rel="previous" href="{base_href}{sep}page={}" type="application/atom+xml;profile=opds-catalog"/>"#,
+            page - 1
+        ));
+        links.push('\n');
+    }
+    let total_pages = (total + PAGE_SIZE - 1) / PAGE_SIZE;
+    if page < total_pages {
+        let sep = if base_href.contains('?') { "&" } else { "?" };
+        links.push_str(&format!(
+            r#"  <link rel="next" href="{base_href}{sep}page={}" type="application/atom+xml;profile=opds-catalog"/>"#,
+            page + 1
+        ));
+        links.push('\n');
+    }
+    links
+}
+
+// ---------------------------------------------------------------------------
+// Route handlers
+// ---------------------------------------------------------------------------
+
+#[derive(serde::Deserialize)]
+pub struct PageQuery {
+    pub page: Option<usize>,
+}
+
+#[derive(serde::Deserialize)]
+pub struct SearchQuery {
+    pub q: Option<String>,
+    pub page: Option<usize>,
+}
+
+/// GET /opds/ — root navigation catalog
+pub async fn root(State(state): State<AppState>, headers: HeaderMap) -> Result<Response, Response> {
+    let _user = basic_auth(&state, &headers).await?;
+
+    let mut body = feed_header("urn:livrarr:opds:root", "Livrarr OPDS Catalog", "/opds/");
+    body.push_str(&nav_entry(
+        "Recent Additions",
+        "/opds/recent",
+        "Recently added books",
+    ));
+    body.push_str(&nav_entry("Authors", "/opds/author", "Browse by author"));
+    body.push_str(&nav_entry("Search", "/opds/search", "Search the library"));
+    body.push_str("</feed>\n");
+
+    Ok(xml_response(body))
+}
+
+/// GET /opds/recent — acquisition feed of newest items
+pub async fn recent(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Query(pq): Query<PageQuery>,
+) -> Result<Response, Response> {
+    let user = basic_auth(&state, &headers).await?;
+    let page = pq.page.unwrap_or(1).max(1);
+
+    let (works, total) = state
+        .db
+        .list_works_paginated(user.id, page as u32, PAGE_SIZE as u32)
+        .await
+        .map_err(api_err_to_response)?;
+
+    let work_ids: Vec<_> = works.iter().map(|w| w.id).collect();
+    let items = state
+        .db
+        .list_library_items_by_work_ids(user.id, &work_ids)
+        .await
+        .map_err(api_err_to_response)?;
+
+    let mut body = feed_header(
+        "urn:livrarr:opds:recent",
+        "Recent Additions",
+        "/opds/recent",
+    );
+    body.push_str(&pagination_links("/opds/recent", page, total as usize));
+
+    for work in &works {
+        let work_items: Vec<_> = items
+            .iter()
+            .filter(|i| i.work_id == work.id)
+            .cloned()
+            .collect();
+        if !work_items.is_empty() {
+            body.push_str(&work_entry(work, &work_items));
+        }
+    }
+
+    body.push_str("</feed>\n");
+    Ok(xml_response(body))
+}
+
+/// GET /opds/author — navigation feed listing authors
+pub async fn author_list(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Response, Response> {
+    let user = basic_auth(&state, &headers).await?;
+
+    let authors = state
+        .db
+        .list_authors(user.id)
+        .await
+        .map_err(api_err_to_response)?;
+
+    let mut body = feed_header("urn:livrarr:opds:authors", "Authors", "/opds/author");
+
+    for author in &authors {
+        body.push_str(&nav_entry(
+            &author.name,
+            &format!("/opds/author/{}", author.id),
+            &format!("Works by {}", author.name),
+        ));
+    }
+
+    body.push_str("</feed>\n");
+    Ok(xml_response(body))
+}
+
+/// GET /opds/author/:id — acquisition feed for author's works
+pub async fn author_works(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(author_id): Path<i64>,
+) -> Result<Response, Response> {
+    let user = basic_auth(&state, &headers).await?;
+
+    let author = state
+        .db
+        .get_author(user.id, author_id)
+        .await
+        .map_err(api_err_to_response)?;
+
+    let works = state
+        .db
+        .list_works(user.id)
+        .await
+        .map_err(api_err_to_response)?;
+
+    let author_works: Vec<_> = works
+        .iter()
+        .filter(|w| w.author_id == Some(author_id))
+        .collect();
+
+    let work_ids: Vec<_> = author_works.iter().map(|w| w.id).collect();
+    let items = state
+        .db
+        .list_library_items_by_work_ids(user.id, &work_ids)
+        .await
+        .map_err(api_err_to_response)?;
+
+    let href = format!("/opds/author/{}", author_id);
+    let mut body = feed_header(
+        &format!("urn:livrarr:opds:author:{}", author_id),
+        &format!("Works by {}", author.name),
+        &href,
+    );
+
+    for work in &author_works {
+        let work_items: Vec<_> = items
+            .iter()
+            .filter(|i| i.work_id == work.id)
+            .cloned()
+            .collect();
+        if !work_items.is_empty() {
+            body.push_str(&work_entry(work, &work_items));
+        }
+    }
+
+    body.push_str("</feed>\n");
+    Ok(xml_response(body))
+}
+
+/// GET /opds/search?q= — acquisition feed with search results
+pub async fn search(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Query(sq): Query<SearchQuery>,
+) -> Result<Response, Response> {
+    let user = basic_auth(&state, &headers).await?;
+    let query = sq.q.unwrap_or_default();
+    let page = sq.page.unwrap_or(1).max(1);
+
+    if query.is_empty() {
+        let mut body = feed_header("urn:livrarr:opds:search", "Search", "/opds/search");
+        body.push_str("</feed>\n");
+        return Ok(xml_response(body));
+    }
+
+    // Simple search: filter works by title or author name containing the query.
+    let all_works = state
+        .db
+        .list_works(user.id)
+        .await
+        .map_err(api_err_to_response)?;
+
+    let query_lower = query.to_lowercase();
+    let matching: Vec<_> = all_works
+        .into_iter()
+        .filter(|w| {
+            w.title.to_lowercase().contains(&query_lower)
+                || w.author_name.to_lowercase().contains(&query_lower)
+        })
+        .collect();
+
+    let total = matching.len();
+    let start = (page - 1) * PAGE_SIZE;
+    let page_works: Vec<_> = matching.into_iter().skip(start).take(PAGE_SIZE).collect();
+
+    let work_ids: Vec<_> = page_works.iter().map(|w| w.id).collect();
+    let items = state
+        .db
+        .list_library_items_by_work_ids(user.id, &work_ids)
+        .await
+        .map_err(api_err_to_response)?;
+
+    let search_href = format!("/opds/search?q={}", urlencoding::encode(&query));
+    let mut body = feed_header(
+        "urn:livrarr:opds:search",
+        &format!("Search: {}", xml_escape(&query)),
+        &search_href,
+    );
+    body.push_str(&pagination_links(&search_href, page, total));
+
+    for work in &page_works {
+        let work_items: Vec<_> = items
+            .iter()
+            .filter(|i| i.work_id == work.id)
+            .cloned()
+            .collect();
+        if !work_items.is_empty() {
+            body.push_str(&work_entry(work, &work_items));
+        }
+    }
+
+    body.push_str("</feed>\n");
+    Ok(xml_response(body))
+}
+
+/// GET /opds/osd — OpenSearch descriptor
+pub async fn opensearch(
+    State(_state): State<AppState>,
+    _headers: HeaderMap,
+) -> Result<Response, Response> {
+    // No auth required for the descriptor itself (some clients fetch it first).
+    let body = r#"<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>Livrarr</ShortName>
+  <Description>Search the Livrarr library</Description>
+  <Url type="application/atom+xml;profile=opds-catalog" template="/opds/search?q={searchTerms}"/>
+</OpenSearchDescription>
+"#
+    .to_string();
+
+    Ok((
+        StatusCode::OK,
+        [(
+            header::CONTENT_TYPE,
+            "application/opensearchdescription+xml;charset=utf-8",
+        )],
+        body,
+    )
+        .into_response())
+}
+
+/// GET /opds/cover/:work_id — serve cover image under Basic Auth
+pub async fn cover(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(work_id): Path<i64>,
+) -> Result<Response, Response> {
+    let _user = basic_auth(&state, &headers).await?;
+
+    // Reuse the mediacover logic: read from data_dir/covers/{work_id}.jpg
+    let cover_path = state
+        .data_dir
+        .join("covers")
+        .join(format!("{}.jpg", work_id));
+
+    if !cover_path.exists() {
+        return Err(StatusCode::NOT_FOUND.into_response());
+    }
+
+    let bytes = tokio::fs::read(&cover_path)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())?;
+
+    Ok((
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "image/jpeg")],
+        bytes,
+    )
+        .into_response())
+}
+
+/// GET /opds/download/:library_item_id — serve file under Basic Auth
+pub async fn download(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(item_id): Path<i64>,
+    req: axum::http::Request<axum::body::Body>,
+) -> Result<Response, Response> {
+    let user = basic_auth(&state, &headers).await?;
+
+    let path = super::workfile::resolve_file_path(&state.db, user.id, item_id)
+        .await
+        .map_err(api_err_to_response)?;
+
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+    let content_type = mime_for_ext(&ext);
+
+    use tower::Service;
+    use tower_http::services::ServeFile;
+    let mut svc = ServeFile::new(&path);
+    let resp = svc.call(req).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("File serve error: {e}"),
+        )
+            .into_response()
+    })?;
+
+    let (mut parts, body) = resp.into_response().into_parts();
+    parts
+        .headers
+        .insert(header::CONTENT_TYPE, content_type.parse().unwrap());
+    Ok(Response::from_parts(parts, body))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn api_err_to_response(e: impl std::fmt::Display) -> Response {
+    (StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")).into_response()
+}

--- a/crates/livrarr-server/src/handlers/workfile.rs
+++ b/crates/livrarr-server/src/handlers/workfile.rs
@@ -1,9 +1,10 @@
 use axum::extract::{Path, Query, State};
+use axum::response::{IntoResponse, Response};
 use axum::Json;
 
 use crate::state::AppState;
 use crate::{ApiError, AuthContext, LibraryItemResponse, PaginatedResponse, PaginationQuery};
-use livrarr_db::{ConfigDb, LibraryItemDb, RootFolderDb};
+use livrarr_db::{ConfigDb, LibraryItemDb, PlaybackProgressDb, RootFolderDb};
 
 fn to_response(li: &livrarr_domain::LibraryItem) -> LibraryItemResponse {
     LibraryItemResponse {
@@ -119,4 +120,119 @@ fn format_bytes(bytes: i64) -> String {
     } else {
         format!("{bytes} B")
     }
+}
+
+/// Resolve a library item to an absolute, canonicalized file path.
+/// Returns 403 if the resolved path escapes the root folder (path traversal protection).
+pub async fn resolve_file_path(
+    db: &(impl LibraryItemDb + RootFolderDb + Send + Sync),
+    user_id: livrarr_domain::UserId,
+    library_item_id: livrarr_domain::LibraryItemId,
+) -> Result<std::path::PathBuf, ApiError> {
+    let item = db.get_library_item(user_id, library_item_id).await?;
+    let root_folder = db.get_root_folder(item.root_folder_id).await?;
+    let root = std::path::Path::new(&root_folder.path);
+    let abs_path = root.join(&item.path);
+
+    // Canonicalize and verify containment.
+    let canonical = abs_path.canonicalize().map_err(|_| ApiError::NotFound)?;
+    let canonical_root = root
+        .canonicalize()
+        .map_err(|e| ApiError::Internal(format!("Root folder not accessible: {e}")))?;
+    if !canonical.starts_with(&canonical_root) {
+        return Err(ApiError::Forbidden);
+    }
+
+    Ok(canonical)
+}
+
+/// Map file extension to Content-Type.
+fn mime_for_ext(ext: &str) -> &'static str {
+    match ext {
+        "epub" => "application/epub+zip",
+        "pdf" => "application/pdf",
+        "mobi" => "application/x-mobipocket-ebook",
+        "azw3" => "application/x-mobi8-ebook",
+        "m4b" | "m4a" => "audio/mp4",
+        "mp3" => "audio/mpeg",
+        "flac" => "audio/flac",
+        "ogg" => "audio/ogg",
+        _ => "application/octet-stream",
+    }
+}
+
+/// GET /api/v1/workfile/:id/download
+pub async fn download(
+    State(state): State<AppState>,
+    ctx: AuthContext,
+    Path(id): Path<i64>,
+    req: axum::http::Request<axum::body::Body>,
+) -> Result<Response, ApiError> {
+    let path = resolve_file_path(&state.db, ctx.user.id, id).await?;
+
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+    let content_type = mime_for_ext(&ext);
+
+    // Use tower_http::services::ServeFile for correct byte-range handling.
+    use tower::Service;
+    use tower_http::services::ServeFile;
+    let mut svc = ServeFile::new(&path);
+    let resp = svc
+        .call(req)
+        .await
+        .map_err(|e| ApiError::Internal(format!("File serve error: {e}")))?;
+
+    // Override content-type to be precise.
+    let (mut parts, body) = resp.into_response().into_parts();
+    parts.headers.insert(
+        axum::http::header::CONTENT_TYPE,
+        content_type.parse().unwrap(),
+    );
+    Ok(Response::from_parts(parts, body))
+}
+
+/// GET /api/v1/workfile/:id/progress
+pub async fn get_progress(
+    State(state): State<AppState>,
+    ctx: AuthContext,
+    Path(id): Path<i64>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let progress = state.db.get_progress(ctx.user.id, id).await?;
+    match progress {
+        Some(p) => Ok(Json(serde_json::json!({
+            "library_item_id": p.library_item_id,
+            "position": p.position,
+            "progress_pct": p.progress_pct,
+            "updated_at": p.updated_at.to_rfc3339(),
+        }))),
+        None => Err(ApiError::NotFound),
+    }
+}
+
+#[derive(serde::Deserialize)]
+pub struct UpdateProgressRequest {
+    pub position: String,
+    pub progress_pct: f64,
+}
+
+/// PUT /api/v1/workfile/:id/progress
+pub async fn update_progress(
+    State(state): State<AppState>,
+    ctx: AuthContext,
+    Path(id): Path<i64>,
+    Json(body): Json<UpdateProgressRequest>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    // Validate the library item exists and belongs to the user.
+    let _item = state.db.get_library_item(ctx.user.id, id).await?;
+
+    let pct = body.progress_pct.clamp(0.0, 1.0);
+    state
+        .db
+        .upsert_progress(ctx.user.id, id, &body.position, pct)
+        .await?;
+    Ok(Json(serde_json::json!({ "success": true })))
 }

--- a/crates/livrarr-server/src/router.rs
+++ b/crates/livrarr-server/src/router.rs
@@ -243,6 +243,11 @@ pub fn build_router(state: AppState, ui_dir: std::path::PathBuf) -> Router {
             "/workfile/{id}/send-email",
             post(handlers::workfile::send_email),
         )
+        .route("/workfile/{id}/download", get(handlers::workfile::download))
+        .route(
+            "/workfile/{id}/progress",
+            get(handlers::workfile::get_progress).put(handlers::workfile::update_progress),
+        )
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),
             auth_middleware,
@@ -268,7 +273,18 @@ pub fn build_router(state: AppState, ui_dir: std::path::PathBuf) -> Router {
         .fallback(|| async { StatusCode::NOT_FOUND })
         .layer(GovernorLayer::new(global_governor));
 
-    let app = Router::new().nest("/api/v1", api);
+    // OPDS routes — top level, before SPA fallback. Basic Auth handled per-handler.
+    let opds = Router::new()
+        .route("/", get(handlers::opds::root))
+        .route("/recent", get(handlers::opds::recent))
+        .route("/author", get(handlers::opds::author_list))
+        .route("/author/{id}", get(handlers::opds::author_works))
+        .route("/search", get(handlers::opds::search))
+        .route("/osd", get(handlers::opds::opensearch))
+        .route("/cover/{work_id}", get(handlers::opds::cover))
+        .route("/download/{library_item_id}", get(handlers::opds::download));
+
+    let app = Router::new().nest("/api/v1", api).nest("/opds", opds);
 
     // Static file serving with SPA fallback.
     let app = if ui_dir.is_dir() {
@@ -296,9 +312,10 @@ pub fn build_router(state: AppState, ui_dir: std::path::PathBuf) -> Router {
     .layer(SetResponseHeaderLayer::overriding(
         axum::http::header::CONTENT_SECURITY_POLICY,
         HeaderValue::from_static(
-            "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; \
-             img-src 'self' data: blob: https: http:; connect-src 'self'; frame-ancestors 'none'; \
-             base-uri 'self'; object-src 'none'; form-action 'self'",
+            "default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; \
+             img-src 'self' data: blob: https: http:; connect-src 'self'; \
+             worker-src 'self' blob:; frame-src 'self' blob:; \
+             frame-ancestors 'none'; base-uri 'self'; object-src 'none'; form-action 'self'",
         ),
     ))
     .with_state(state)


### PR DESCRIPTION
## Summary
- **OPDS 1.2 catalog** with Basic Auth (username + API key) — 8 endpoints for e-reader integration (KOReader, Thorium, Moon+ Reader): root navigation, recent acquisitions, author browse, search with OpenSearch, cover proxy, file download
- **File download endpoint** (`/api/v1/workfile/{id}/download`) with byte-range support via `tower_http::ServeFile` and path traversal protection (canonicalization + root containment)
- **Playback progress tracking** (`GET/PUT /api/v1/workfile/{id}/progress`) — stores reading/listening position (EPUB CFI, PDF page number, audio timestamp) and progress percentage
- **CSP updated** for epub.js and PDF.js: `blob:` in `script-src`, `worker-src 'self' blob:`, `frame-src 'self' blob:`

## Files changed
- New: `018_playback_progress.sql`, `sqlite_playback_progress.rs`, `opds.rs` (543 lines)
- Modified: `workfile.rs` (+118 lines), `router.rs`, `lib.rs` (domain + db), `mod.rs`, `Cargo.toml`

## Test plan
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --workspace --all-targets` — no new warnings
- [ ] `cargo test --workspace --exclude livrarr-metadata` passes
- [ ] OPDS feed validates in an OPDS client (KOReader or Thorium)
- [ ] File download works with byte-range requests (audio seeks correctly)
- [ ] Progress save/restore round-trips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)