### PR TITLE
Readarr library import: three-phase flow with undo

### DIFF
--- a/crates/livrarr-db/migrations/017_readarr_import.sql
+++ b/crates/livrarr-db/migrations/017_readarr_import.sql
@@ -1,0 +1,25 @@
+-- Readarr Library Import: import tracking and import attribution.
+
+-- Imports tracking table.
+CREATE TABLE imports (
+    id TEXT PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    source TEXT NOT NULL DEFAULT 'readarr',
+    status TEXT NOT NULL DEFAULT 'running' CHECK (status IN ('running', 'completed', 'failed', 'undone')),
+    started_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    completed_at TEXT,
+    authors_created INTEGER NOT NULL DEFAULT 0,
+    works_created INTEGER NOT NULL DEFAULT 0,
+    files_imported INTEGER NOT NULL DEFAULT 0,
+    files_skipped INTEGER NOT NULL DEFAULT 0,
+    source_url TEXT,
+    target_root_folder_id INTEGER REFERENCES root_folders(id)
+);
+
+-- One running import per user.
+CREATE UNIQUE INDEX idx_imports_running ON imports(user_id) WHERE status = 'running';
+
+-- Import attribution on works, authors, library_items.
+ALTER TABLE works ADD COLUMN import_id TEXT REFERENCES imports(id);
+ALTER TABLE authors ADD COLUMN import_id TEXT REFERENCES imports(id);
+ALTER TABLE library_items ADD COLUMN import_id TEXT REFERENCES imports(id);

--- a/crates/livrarr-db/src/lib.rs
+++ b/crates/livrarr-db/src/lib.rs
@@ -2,9 +2,9 @@ use serde::Deserialize;
 
 pub use livrarr_domain::{
     Author, AuthorId, DbError, DownloadClient, DownloadClientId, DownloadClientImplementation,
-    EnrichmentStatus, EventType, Grab, GrabId, GrabStatus, HistoryEvent, HistoryId, Indexer,
-    IndexerConfig, IndexerId, IndexerRssState, LibraryItem, LibraryItemId, LlmProvider, MediaType,
-    NarrationType, Notification, NotificationId, NotificationType, PlaybackProgress,
+    EnrichmentStatus, EventType, Grab, GrabId, GrabStatus, HistoryEvent, HistoryId, Import,
+    Indexer, IndexerConfig, IndexerId, IndexerRssState, LibraryItem, LibraryItemId, LlmProvider,
+    MediaType, NarrationType, Notification, NotificationId, NotificationType, PlaybackProgress,
     RemotePathMapping, RemotePathMappingId, RootFolder, RootFolderId, Session, User, UserId,
     UserRole, Work, WorkId,
 };
@@ -18,6 +18,7 @@ mod sqlite_config;
 mod sqlite_download_client;
 mod sqlite_grab;
 mod sqlite_history;
+mod sqlite_import;
 mod sqlite_indexer;
 mod sqlite_library_item;
 mod sqlite_notification;
@@ -245,6 +246,7 @@ pub struct CreateWorkDbRequest {
     pub metadata_source: Option<String>,
     pub detail_url: Option<String>,
     pub language: Option<String>,
+    pub import_id: Option<String>,
 }
 
 pub struct UpdateWorkEnrichmentDbRequest {
@@ -335,6 +337,7 @@ pub struct CreateAuthorDbRequest {
     pub ol_key: Option<String>,
     pub gr_key: Option<String>,
     pub hc_key: Option<String>,
+    pub import_id: Option<String>,
 }
 
 pub struct UpdateAuthorDbRequest {
@@ -450,6 +453,7 @@ pub struct CreateLibraryItemDbRequest {
     pub path: String,
     pub media_type: MediaType,
     pub file_size: i64,
+    pub import_id: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1062,6 +1066,54 @@ pub trait AuthorBibliographyDb: Send + Sync {
     ) -> Result<AuthorBibliography, DbError>;
 }
 
+// ---------------------------------------------------------------------------
+// Import DB (Readarr Library Import)
+// ---------------------------------------------------------------------------
+
+/// Import tracking data access.
+#[trait_variant::make(Send)]
+pub trait ImportDb: Send + Sync {
+    /// Create an import record.
+    async fn create_import(&self, req: CreateImportDbRequest) -> Result<(), DbError>;
+
+    /// Get an import by ID.
+    async fn get_import(&self, id: &str) -> Result<Option<Import>, DbError>;
+
+    /// List imports for a user (most recent first).
+    async fn list_imports(&self, user_id: UserId) -> Result<Vec<Import>, DbError>;
+
+    /// Update import status.
+    async fn update_import_status(&self, id: &str, status: &str) -> Result<(), DbError>;
+
+    /// Update import counters.
+    async fn update_import_counts(
+        &self,
+        id: &str,
+        authors: i64,
+        works: i64,
+        files: i64,
+        skipped: i64,
+    ) -> Result<(), DbError>;
+
+    /// Mark import as completed (set status + completed_at timestamp).
+    async fn set_import_completed(&self, id: &str) -> Result<(), DbError>;
+
+    /// List library items by import_id (for undo).
+    async fn list_library_items_by_import(
+        &self,
+        import_id: &str,
+    ) -> Result<Vec<LibraryItem>, DbError>;
+
+    /// Delete a library item by ID (no user scope — for undo).
+    async fn delete_library_item_by_id(&self, id: LibraryItemId) -> Result<(), DbError>;
+
+    /// Delete works by import_id that have zero library items.
+    async fn delete_orphan_works_by_import(&self, import_id: &str) -> Result<i64, DbError>;
+
+    /// Delete authors by import_id that have zero works.
+    async fn delete_orphan_authors_by_import(&self, import_id: &str) -> Result<i64, DbError>;
+}
+
 /// Playback progress data access.
 #[trait_variant::make(Send)]
 pub trait PlaybackProgressDb: Send + Sync {
@@ -1080,6 +1132,14 @@ pub trait PlaybackProgressDb: Send + Sync {
         position: &str,
         progress_pct: f64,
     ) -> Result<(), DbError>;
+}
+
+pub struct CreateImportDbRequest {
+    pub id: String,
+    pub user_id: UserId,
+    pub source: String,
+    pub source_url: Option<String>,
+    pub target_root_folder_id: Option<i64>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/livrarr-db/src/sqlite_author.rs
+++ b/crates/livrarr-db/src/sqlite_author.rs
@@ -35,6 +35,9 @@ fn row_to_author(row: sqlx::sqlite::SqliteRow) -> Result<Author, DbError> {
         hc_key: row
             .try_get("hc_key")
             .map_err(|e| DbError::Io(Box::new(e)))?,
+        import_id: row
+            .try_get("import_id")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
         monitored: row
             .try_get::<bool, _>("monitored")
             .map_err(|e| DbError::Io(Box::new(e)))?,
@@ -69,8 +72,8 @@ impl AuthorDb for SqliteDb {
     async fn create_author(&self, req: CreateAuthorDbRequest) -> Result<Author, DbError> {
         let now = Utc::now().to_rfc3339();
         let id = sqlx::query(
-            "INSERT INTO authors (user_id, name, sort_name, ol_key, gr_key, hc_key, added_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO authors (user_id, name, sort_name, ol_key, gr_key, hc_key, import_id, added_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(req.user_id)
         .bind(&req.name)
@@ -78,6 +81,7 @@ impl AuthorDb for SqliteDb {
         .bind(&req.ol_key)
         .bind(&req.gr_key)
         .bind(&req.hc_key)
+        .bind(&req.import_id)
         .bind(&now)
         .execute(self.pool())
         .await

--- a/crates/livrarr-db/src/sqlite_import.rs
+++ b/crates/livrarr-db/src/sqlite_import.rs
@@ -1,0 +1,222 @@
+use chrono::Utc;
+use sqlx::Row;
+
+use crate::sqlite::SqliteDb;
+use crate::sqlite_common::{map_db_err, parse_dt};
+use crate::{
+    CreateImportDbRequest, DbError, Import, ImportDb, LibraryItem, LibraryItemId, MediaType, UserId,
+};
+
+fn row_to_import(row: sqlx::sqlite::SqliteRow) -> Result<Import, DbError> {
+    let started_at_str: String = row
+        .try_get("started_at")
+        .map_err(|e| DbError::Io(Box::new(e)))?;
+    let completed_at_str: Option<String> = row
+        .try_get("completed_at")
+        .map_err(|e| DbError::Io(Box::new(e)))?;
+
+    Ok(Import {
+        id: row.try_get("id").map_err(|e| DbError::Io(Box::new(e)))?,
+        user_id: row
+            .try_get::<i64, _>("user_id")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
+        source: row
+            .try_get("source")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
+        status: row
+            .try_get("status")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
+        started_at: parse_dt(&started_at_str)?,
+        completed_at: completed_at_str.map(|s| parse_dt(&s)).transpose()?,
+        authors_created: row
+            .try_get::<i64, _>("authors_created")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
+        works_created: row
+            .try_get::<i64, _>("works_created")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
+        files_imported: row
+            .try_get::<i64, _>("files_imported")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
+        files_skipped: row
+            .try_get::<i64, _>("files_skipped")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
+        source_url: row
+            .try_get("source_url")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
+        target_root_folder_id: row
+            .try_get("target_root_folder_id")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
+    })
+}
+
+fn parse_media_type(s: &str) -> Result<MediaType, DbError> {
+    match s {
+        "ebook" => Ok(MediaType::Ebook),
+        "audiobook" => Ok(MediaType::Audiobook),
+        _ => Err(DbError::IncompatibleData {
+            detail: format!("unknown media type: {s}"),
+        }),
+    }
+}
+
+fn row_to_library_item(row: sqlx::sqlite::SqliteRow) -> Result<LibraryItem, DbError> {
+    let media_type_str: String = row
+        .try_get("media_type")
+        .map_err(|e| DbError::Io(Box::new(e)))?;
+    let imported_at_str: String = row
+        .try_get("imported_at")
+        .map_err(|e| DbError::Io(Box::new(e)))?;
+
+    Ok(LibraryItem {
+        id: row
+            .try_get::<i64, _>("id")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
+        user_id: row
+            .try_get::<i64, _>("user_id")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
+        work_id: row
+            .try_get::<i64, _>("work_id")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
+        root_folder_id: row
+            .try_get::<i64, _>("root_folder_id")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
+        path: row.try_get("path").map_err(|e| DbError::Io(Box::new(e)))?,
+        media_type: parse_media_type(&media_type_str)?,
+        file_size: row
+            .try_get::<i64, _>("file_size")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
+        import_id: row
+            .try_get("import_id")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
+        imported_at: parse_dt(&imported_at_str)?,
+    })
+}
+
+impl ImportDb for SqliteDb {
+    async fn create_import(&self, req: CreateImportDbRequest) -> Result<(), DbError> {
+        let now = Utc::now().to_rfc3339();
+        sqlx::query(
+            "INSERT INTO imports (id, user_id, source, status, started_at, source_url, target_root_folder_id) \
+             VALUES (?, ?, ?, 'running', ?, ?, ?)",
+        )
+        .bind(&req.id)
+        .bind(req.user_id)
+        .bind(&req.source)
+        .bind(&now)
+        .bind(&req.source_url)
+        .bind(req.target_root_folder_id)
+        .execute(self.pool())
+        .await
+        .map_err(map_db_err)?;
+        Ok(())
+    }
+
+    async fn get_import(&self, id: &str) -> Result<Option<Import>, DbError> {
+        let row = sqlx::query("SELECT * FROM imports WHERE id = ?")
+            .bind(id)
+            .fetch_optional(self.pool())
+            .await
+            .map_err(map_db_err)?;
+        match row {
+            Some(r) => Ok(Some(row_to_import(r)?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn list_imports(&self, user_id: UserId) -> Result<Vec<Import>, DbError> {
+        let rows = sqlx::query("SELECT * FROM imports WHERE user_id = ? ORDER BY started_at DESC")
+            .bind(user_id)
+            .fetch_all(self.pool())
+            .await
+            .map_err(map_db_err)?;
+        rows.into_iter().map(row_to_import).collect()
+    }
+
+    async fn update_import_status(&self, id: &str, status: &str) -> Result<(), DbError> {
+        sqlx::query("UPDATE imports SET status = ? WHERE id = ?")
+            .bind(status)
+            .bind(id)
+            .execute(self.pool())
+            .await
+            .map_err(map_db_err)?;
+        Ok(())
+    }
+
+    async fn update_import_counts(
+        &self,
+        id: &str,
+        authors: i64,
+        works: i64,
+        files: i64,
+        skipped: i64,
+    ) -> Result<(), DbError> {
+        sqlx::query(
+            "UPDATE imports SET authors_created = ?, works_created = ?, files_imported = ?, files_skipped = ? WHERE id = ?",
+        )
+        .bind(authors)
+        .bind(works)
+        .bind(files)
+        .bind(skipped)
+        .bind(id)
+        .execute(self.pool())
+        .await
+        .map_err(map_db_err)?;
+        Ok(())
+    }
+
+    async fn set_import_completed(&self, id: &str) -> Result<(), DbError> {
+        let now = Utc::now().to_rfc3339();
+        sqlx::query("UPDATE imports SET status = 'completed', completed_at = ? WHERE id = ?")
+            .bind(&now)
+            .bind(id)
+            .execute(self.pool())
+            .await
+            .map_err(map_db_err)?;
+        Ok(())
+    }
+
+    async fn list_library_items_by_import(
+        &self,
+        import_id: &str,
+    ) -> Result<Vec<LibraryItem>, DbError> {
+        let rows = sqlx::query("SELECT * FROM library_items WHERE import_id = ? ORDER BY id")
+            .bind(import_id)
+            .fetch_all(self.pool())
+            .await
+            .map_err(map_db_err)?;
+        rows.into_iter().map(row_to_library_item).collect()
+    }
+
+    async fn delete_library_item_by_id(&self, id: LibraryItemId) -> Result<(), DbError> {
+        sqlx::query("DELETE FROM library_items WHERE id = ?")
+            .bind(id)
+            .execute(self.pool())
+            .await
+            .map_err(map_db_err)?;
+        Ok(())
+    }
+
+    async fn delete_orphan_works_by_import(&self, import_id: &str) -> Result<i64, DbError> {
+        let result = sqlx::query(
+            "DELETE FROM works WHERE import_id = ? AND id NOT IN \
+             (SELECT DISTINCT work_id FROM library_items WHERE work_id IS NOT NULL)",
+        )
+        .bind(import_id)
+        .execute(self.pool())
+        .await
+        .map_err(map_db_err)?;
+        Ok(result.rows_affected() as i64)
+    }
+
+    async fn delete_orphan_authors_by_import(&self, import_id: &str) -> Result<i64, DbError> {
+        let result = sqlx::query(
+            "DELETE FROM authors WHERE import_id = ? AND id NOT IN \
+             (SELECT DISTINCT author_id FROM works WHERE author_id IS NOT NULL)",
+        )
+        .bind(import_id)
+        .execute(self.pool())
+        .await
+        .map_err(map_db_err)?;
+        Ok(result.rows_affected() as i64)
+    }
+}

--- a/crates/livrarr-db/src/sqlite_library_item.rs
+++ b/crates/livrarr-db/src/sqlite_library_item.rs
@@ -34,6 +34,9 @@ fn row_to_library_item(row: sqlx::sqlite::SqliteRow) -> Result<LibraryItem, DbEr
         file_size: row
             .try_get::<i64, _>("file_size")
             .map_err(|e| DbError::Io(Box::new(e)))?,
+        import_id: row
+            .try_get("import_id")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
         imported_at: parse_dt(&imported_at_str)?,
     })
 }
@@ -201,8 +204,8 @@ impl LibraryItemDb for SqliteDb {
 
         // No conflict -- insert new row.
         let id = sqlx::query(
-            "INSERT INTO library_items (user_id, work_id, root_folder_id, path, media_type, file_size, imported_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO library_items (user_id, work_id, root_folder_id, path, media_type, file_size, import_id, imported_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(req.user_id)
         .bind(req.work_id)
@@ -210,6 +213,7 @@ impl LibraryItemDb for SqliteDb {
         .bind(&req.path)
         .bind(mt)
         .bind(req.file_size)
+        .bind(&req.import_id)
         .bind(&now)
         .execute(self.pool())
         .await

--- a/crates/livrarr-db/src/sqlite_work.rs
+++ b/crates/livrarr-db/src/sqlite_work.rs
@@ -135,6 +135,9 @@ fn row_to_work(row: sqlx::sqlite::SqliteRow) -> Result<Work, DbError> {
         monitor_audiobook: row
             .try_get::<bool, _>("monitor_audiobook")
             .map_err(|e| DbError::Io(Box::new(e)))?,
+        import_id: row
+            .try_get("import_id")
+            .map_err(|e| DbError::Io(Box::new(e)))?,
         added_at: parse_dt(&added_at_str)?,
         metadata_source: row
             .try_get("metadata_source")
@@ -248,8 +251,8 @@ impl WorkDb for SqliteDb {
         let now = Utc::now().to_rfc3339();
         let id = sqlx::query(
             "INSERT INTO works (user_id, title, author_name, author_id, ol_key, gr_key, year, \
-             cover_url, enrichment_status, added_at, metadata_source, detail_url, language) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?)",
+             cover_url, enrichment_status, added_at, metadata_source, detail_url, language, import_id) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?)",
         )
         .bind(req.user_id)
         .bind(&req.title)
@@ -263,6 +266,7 @@ impl WorkDb for SqliteDb {
         .bind(&req.metadata_source)
         .bind(&req.detail_url)
         .bind(&req.language)
+        .bind(&req.import_id)
         .execute(self.pool())
         .await
         .map_err(map_db_err)?

--- a/crates/livrarr-domain/src/lib.rs
+++ b/crates/livrarr-domain/src/lib.rs
@@ -359,6 +359,7 @@ pub struct Work {
     pub cover_manual: bool,
     pub monitor_ebook: bool,
     pub monitor_audiobook: bool,
+    pub import_id: Option<String>,
     pub added_at: DateTime<Utc>,
     /// Foreign language provider attribution (e.g., "BnF", "lubimyczytac.pl").
     /// Null for existing English/OL works.
@@ -382,6 +383,7 @@ pub struct Author {
     pub ol_key: Option<String>,
     pub gr_key: Option<String>,
     pub hc_key: Option<String>,
+    pub import_id: Option<String>,
     pub monitored: bool,
     pub monitor_new_items: bool,
     pub monitor_since: Option<DateTime<Utc>>,
@@ -400,6 +402,7 @@ pub struct LibraryItem {
     pub path: String,
     pub media_type: MediaType,
     pub file_size: i64,
+    pub import_id: Option<String>,
     pub imported_at: DateTime<Utc>,
 }
 
@@ -608,6 +611,23 @@ pub struct IndexerRssState {
 pub struct IndexerConfig {
     pub rss_sync_interval_minutes: i32,
     pub rss_match_threshold: f64,
+}
+
+/// Import record — tracks a Readarr library import.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Import {
+    pub id: String,
+    pub user_id: UserId,
+    pub source: String,
+    pub status: String,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub authors_created: i64,
+    pub works_created: i64,
+    pub files_imported: i64,
+    pub files_skipped: i64,
+    pub source_url: Option<String>,
+    pub target_root_folder_id: Option<i64>,
 }
 
 /// Sanitizes a path component for filesystem use.

--- a/crates/livrarr-server/src/api_secondary_impl.rs
+++ b/crates/livrarr-server/src/api_secondary_impl.rs
@@ -84,6 +84,7 @@ impl AuthorApi for SecondaryApiImpl {
                 ol_key: Some(req.ol_key),
                 gr_key: None,
                 hc_key: None,
+                import_id: None,
             })
             .await
             .map_err(db_err)?;
@@ -838,6 +839,7 @@ impl SecondaryApiImpl {
                 ol_key: None,
                 gr_key: None,
                 hc_key: None,
+                import_id: None,
             })
             .await
             .unwrap();
@@ -879,6 +881,7 @@ impl SecondaryApiImpl {
                 metadata_source: None,
                 detail_url: None,
                 language: None,
+                import_id: None,
             })
             .await
             .unwrap();
@@ -894,6 +897,7 @@ impl SecondaryApiImpl {
                 ),
                 media_type: MediaType::Ebook,
                 file_size: 1234,
+                import_id: None,
             })
             .await
             .unwrap();
@@ -936,6 +940,7 @@ impl SecondaryApiImpl {
                 metadata_source: None,
                 detail_url: None,
                 language: None,
+                import_id: None,
             })
             .await
             .unwrap();
@@ -948,6 +953,7 @@ impl SecondaryApiImpl {
                 path: path_str.clone(),
                 media_type: MediaType::Ebook,
                 file_size: 12,
+                import_id: None,
             })
             .await
             .unwrap();

--- a/crates/livrarr-server/src/handlers/author.rs
+++ b/crates/livrarr-server/src/handlers/author.rs
@@ -174,6 +174,7 @@ pub async fn add(
             ol_key: Some(req.ol_key),
             gr_key: None,
             hc_key: None,
+            import_id: None,
         })
         .await?;
 

--- a/crates/livrarr-server/src/handlers/import.rs
+++ b/crates/livrarr-server/src/handlers/import.rs
@@ -258,6 +258,7 @@ pub async fn import_grab(
                     path: relative,
                     media_type,
                     file_size,
+                    import_id: None,
                 })
                 .await
             {
@@ -544,6 +545,7 @@ pub async fn import_single_file(
             path: relative,
             media_type,
             file_size,
+            import_id: None,
         })
         .await
         .map_err(|e| {
@@ -769,6 +771,7 @@ async fn import_mp3_batch(
                 path: relative,
                 media_type: vf.media_type,
                 file_size,
+                import_id: None,
             })
             .await
         {

--- a/crates/livrarr-server/src/handlers/manual_import.rs
+++ b/crates/livrarr-server/src/handlers/manual_import.rs
@@ -788,6 +788,7 @@ async fn import_single_item(
                 path: relative.to_string(),
                 media_type,
                 file_size,
+                import_id: None,
             })
             .await
         {

--- a/crates/livrarr-server/src/handlers/mod.rs
+++ b/crates/livrarr-server/src/handlers/mod.rs
@@ -15,6 +15,7 @@ pub mod notification;
 pub mod opds;
 pub mod profile;
 pub mod queue;
+pub mod readarr_import;
 pub mod release;
 pub mod remote_path_mapping;
 pub mod root_folder;

--- a/crates/livrarr-server/src/handlers/readarr_import.rs
+++ b/crates/livrarr-server/src/handlers/readarr_import.rs
@@ -1,0 +1,1294 @@
+//! Readarr Library Import handler.
+//!
+//! Endpoints: connect, preview, start, progress, history, undo.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use axum::extract::{Path as AxumPath, State};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use tracing::{error, info, warn};
+
+use crate::readarr_client::{self, RdAuthor, RdBook, RdBookFile, RdRootFolder, ReadarrClient};
+use crate::state::AppState;
+use crate::{ApiError, AuthContext};
+use livrarr_db::{
+    AuthorDb, CreateAuthorDbRequest, CreateImportDbRequest, CreateLibraryItemDbRequest,
+    CreateWorkDbRequest, ImportDb, LibraryItemDb, RootFolderDb, WorkDb,
+};
+use livrarr_domain::{
+    derive_sort_name, normalize_for_matching, sanitize_path_component, Import, MediaType,
+};
+
+// ---------------------------------------------------------------------------
+// Request / Response types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConnectRequest {
+    pub url: String,
+    pub api_key: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConnectResponse {
+    pub root_folders: Vec<RootFolderInfo>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RootFolderInfo {
+    pub id: i64,
+    pub name: Option<String>,
+    pub path: String,
+    pub accessible: Option<bool>,
+    pub free_space: Option<i64>,
+    pub total_space: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreviewRequest {
+    pub url: String,
+    pub api_key: String,
+    pub readarr_root_folder_id: i64,
+    pub livrarr_root_folder_id: i64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreviewResponse {
+    pub authors_to_create: i64,
+    pub authors_existing: i64,
+    pub works_to_create: i64,
+    pub works_existing: i64,
+    pub files_to_import: i64,
+    pub files_to_skip: i64,
+    pub skipped_items: Vec<SkippedItem>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkippedItem {
+    pub title: String,
+    pub author: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartRequest {
+    pub url: String,
+    pub api_key: String,
+    pub readarr_root_folder_id: i64,
+    pub livrarr_root_folder_id: i64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartResponse {
+    pub import_id: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportProgress {
+    pub running: bool,
+    pub import_id: Option<String>,
+    pub phase: String,
+    pub authors_processed: i64,
+    pub authors_total: i64,
+    pub works_processed: i64,
+    pub works_total: i64,
+    pub files_processed: i64,
+    pub files_total: i64,
+    pub files_skipped: i64,
+    pub errors: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportHistoryResponse {
+    pub imports: Vec<ImportRecord>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportRecord {
+    pub id: String,
+    pub source: String,
+    pub status: String,
+    pub started_at: String,
+    pub completed_at: Option<String>,
+    pub authors_created: i64,
+    pub works_created: i64,
+    pub files_imported: i64,
+    pub files_skipped: i64,
+    pub source_url: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UndoResponse {
+    pub files_deleted: i64,
+    pub files_skipped: i64,
+    pub works_deleted: i64,
+    pub authors_deleted: i64,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn import_to_record(imp: &Import) -> ImportRecord {
+    ImportRecord {
+        id: imp.id.clone(),
+        source: imp.source.clone(),
+        status: imp.status.clone(),
+        started_at: imp.started_at.to_rfc3339(),
+        completed_at: imp.completed_at.map(|d| d.to_rfc3339()),
+        authors_created: imp.authors_created,
+        works_created: imp.works_created,
+        files_imported: imp.files_imported,
+        files_skipped: imp.files_skipped,
+        source_url: imp.source_url.clone(),
+    }
+}
+
+/// Determine media type from Readarr quality ID, falling back to file extension.
+fn resolve_media_type(quality_id: Option<i32>, path: &str) -> Option<MediaType> {
+    if let Some(qid) = quality_id {
+        if let Some(mt_str) = readarr_client::quality_to_media_type(qid) {
+            return match mt_str {
+                "ebook" => Some(MediaType::Ebook),
+                "audiobook" => Some(MediaType::Audiobook),
+                _ => None,
+            };
+        }
+    }
+    // Fallback to extension.
+    if let Some(mt_str) = readarr_client::media_type_from_extension(path) {
+        return match mt_str {
+            "ebook" => Some(MediaType::Ebook),
+            "audiobook" => Some(MediaType::Audiobook),
+            _ => None,
+        };
+    }
+    None
+}
+
+/// Extract quality ID from Readarr book file.
+fn extract_quality_id(bf: &RdBookFile) -> Option<i32> {
+    bf.quality.as_ref()?.quality.as_ref().map(|q| q.id)
+}
+
+/// Parse series title: "Series Name #1.5; Other Series #2" -> (series_name, series_position)
+/// Only uses the first semicolon-delimited segment.
+fn parse_series_title(series_title: &str) -> (Option<String>, Option<f64>) {
+    let segment = series_title
+        .split(';')
+        .next()
+        .unwrap_or(series_title)
+        .trim();
+    if segment.is_empty() {
+        return (None, None);
+    }
+
+    let re = regex::Regex::new(r"^(.*?)(?:\s+#([\d.]+))?$").unwrap();
+    if let Some(caps) = re.captures(segment) {
+        let name = caps.get(1).map(|m| m.as_str().trim().to_string());
+        let pos = caps.get(2).and_then(|m| m.as_str().parse::<f64>().ok());
+        let name = name.filter(|n| !n.is_empty());
+        (name, pos)
+    } else {
+        (Some(segment.to_string()), None)
+    }
+}
+
+/// Extract year from a date string like "2024-01-15T00:00:00Z" or "2024".
+fn extract_year(date_str: &str) -> Option<i32> {
+    date_str.get(..4)?.parse::<i32>().ok()
+}
+
+/// Get the cover URL from Readarr images, preferring remote_url for covers.
+fn extract_cover_url(images: &Option<Vec<readarr_client::RdImage>>) -> Option<String> {
+    let imgs = images.as_ref()?;
+    // Prefer a "cover" type image.
+    for img in imgs {
+        if img.cover_type.as_deref() == Some("cover") {
+            if let Some(ref url) = img.remote_url {
+                if !url.is_empty() {
+                    return Some(url.clone());
+                }
+            }
+            if let Some(ref url) = img.url {
+                if !url.is_empty() {
+                    return Some(url.clone());
+                }
+            }
+        }
+    }
+    // Fallback: first image with a URL.
+    for img in imgs {
+        if let Some(ref url) = img.remote_url {
+            if !url.is_empty() {
+                return Some(url.clone());
+            }
+        }
+        if let Some(ref url) = img.url {
+            if !url.is_empty() {
+                return Some(url.clone());
+            }
+        }
+    }
+    None
+}
+
+/// Build destination path: {root}/{Author Name}/{Title}.{ext}
+fn build_dest_path(root: &str, author_name: &str, title: &str, source_path: &str) -> PathBuf {
+    let ext = Path::new(source_path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("bin");
+    let author_dir = sanitize_path_component(author_name, "Unknown Author");
+    let file_stem = sanitize_path_component(title, "Unknown Title");
+    PathBuf::from(root)
+        .join(author_dir)
+        .join(format!("{file_stem}.{ext}"))
+}
+
+/// Canonicalize source path and verify it's under the expected root.
+fn validate_source_path(source: &str, readarr_root: &str) -> Result<PathBuf, String> {
+    let canonical = std::fs::canonicalize(source)
+        .map_err(|e| format!("cannot canonicalize source path: {e}"))?;
+    let root_canonical = std::fs::canonicalize(readarr_root)
+        .map_err(|e| format!("cannot canonicalize readarr root: {e}"))?;
+    if !canonical.starts_with(&root_canonical) {
+        return Err(format!(
+            "source path {canonical:?} is not under readarr root {root_canonical:?}"
+        ));
+    }
+    Ok(canonical)
+}
+
+/// Try hardlink, fall back to copy with temp+rename.
+fn materialize_file(source: &Path, dest: &Path) -> Result<(), String> {
+    // Ensure parent directory exists.
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("mkdir failed: {e}"))?;
+    }
+
+    // Try hardlink first.
+    if std::fs::hard_link(source, dest).is_ok() {
+        return Ok(());
+    }
+
+    // Fallback: copy to temp, verify size, atomic rename.
+    let temp = dest.with_extension(format!("tmp.{}", uuid::Uuid::new_v4()));
+    match std::fs::copy(source, &temp) {
+        Ok(copied) => {
+            let source_size = std::fs::metadata(source)
+                .map_err(|e| format!("cannot stat source: {e}"))?
+                .len();
+            if copied != source_size {
+                let _ = std::fs::remove_file(&temp);
+                return Err(format!(
+                    "copy size mismatch: copied {copied} vs source {source_size}"
+                ));
+            }
+            std::fs::rename(&temp, dest).map_err(|e| {
+                let _ = std::fs::remove_file(&temp);
+                format!("rename failed: {e}")
+            })
+        }
+        Err(e) => {
+            let _ = std::fs::remove_file(&temp);
+            Err(format!("copy failed: {e}"))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// POST /api/v1/import/readarr/connect
+pub async fn connect(
+    State(state): State<AppState>,
+    _auth: AuthContext,
+    Json(req): Json<ConnectRequest>,
+) -> Result<Json<ConnectResponse>, ApiError> {
+    if req.url.is_empty() {
+        return Err(ApiError::BadRequest("url is required".into()));
+    }
+    if req.api_key.is_empty() {
+        return Err(ApiError::BadRequest("apiKey is required".into()));
+    }
+
+    let client = ReadarrClient::new(
+        &req.url,
+        &req.api_key,
+        state.http_client_safe.inner().clone(),
+    );
+    let folders = client
+        .root_folders()
+        .await
+        .map_err(|e| ApiError::BadGateway(format!("Failed to connect to Readarr: {e}")))?;
+
+    let root_folders = folders
+        .into_iter()
+        .map(|f| RootFolderInfo {
+            id: f.id,
+            name: f.name,
+            path: f.path,
+            accessible: f.accessible,
+            free_space: f.free_space,
+            total_space: f.total_space,
+        })
+        .collect();
+
+    Ok(Json(ConnectResponse { root_folders }))
+}
+
+/// POST /api/v1/import/readarr/preview
+pub async fn preview(
+    State(state): State<AppState>,
+    auth: AuthContext,
+    Json(req): Json<PreviewRequest>,
+) -> Result<Json<PreviewResponse>, ApiError> {
+    let user_id = auth.user.id;
+
+    // Fetch all data from Readarr.
+    let client = ReadarrClient::new(
+        &req.url,
+        &req.api_key,
+        state.http_client_safe.inner().clone(),
+    );
+
+    let (authors, books, book_files, rd_folders) = fetch_all_readarr_data(&client).await?;
+
+    // Validate the selected Readarr root folder exists.
+    let _readarr_root = rd_folders
+        .iter()
+        .find(|f| f.id == req.readarr_root_folder_id)
+        .map(|f| f.path.clone())
+        .ok_or_else(|| ApiError::BadRequest("Invalid Readarr root folder ID".into()))?;
+
+    // Get Livrarr root folder.
+    let livrarr_root = state.db.get_root_folder(req.livrarr_root_folder_id).await?;
+
+    // Build maps.
+    let author_map: HashMap<i64, &RdAuthor> = authors.iter().map(|a| (a.id, a)).collect();
+    let mut book_files_by_book: HashMap<i64, Vec<&RdBookFile>> = HashMap::new();
+    for bf in &book_files {
+        book_files_by_book.entry(bf.book_id).or_default().push(bf);
+    }
+
+    // Load existing authors and works for dedup.
+    let existing_authors = state.db.list_authors(user_id).await?;
+    let existing_works = state.db.list_works(user_id).await?;
+
+    let mut skipped_items = Vec::new();
+    let mut authors_to_create = 0i64;
+    let mut works_to_create = 0i64;
+    let mut works_existing = 0i64;
+    let mut files_to_import = 0i64;
+    let mut files_to_skip = 0i64;
+
+    // Track authors we'll create (by normalized name) to avoid counting duplicates.
+    let mut author_names_seen: HashMap<String, bool> = HashMap::new(); // true = existing
+    for a in &existing_authors {
+        author_names_seen.insert(normalize_for_matching(&a.name), true);
+    }
+
+    for book in &books {
+        let author_name = author_map
+            .get(&book.author_id)
+            .and_then(|a| a.author_name.as_deref())
+            .unwrap_or("");
+        let title = book.title.as_deref().unwrap_or("");
+
+        // Skip books with no author.
+        if author_name.is_empty() {
+            skipped_items.push(SkippedItem {
+                title: title.to_string(),
+                author: String::new(),
+                reason: "No author".to_string(),
+            });
+            continue;
+        }
+
+        // Author dedup.
+        let norm_author = normalize_for_matching(author_name);
+        if !author_names_seen.contains_key(&norm_author) {
+            author_names_seen.insert(norm_author.clone(), false);
+            authors_to_create += 1;
+        } else if *author_names_seen.get(&norm_author).unwrap() {
+            // Existing author, already counted.
+        }
+
+        // Check files for this book.
+        let files = book_files_by_book.get(&book.id);
+        let file_list: Vec<&&RdBookFile> = files.map(|f| f.iter().collect()).unwrap_or_default();
+
+        // Multi-file audiobook detection.
+        let audiobook_count = file_list
+            .iter()
+            .filter(|f| {
+                let qid = extract_quality_id(f);
+                resolve_media_type(qid, &f.path) == Some(MediaType::Audiobook)
+            })
+            .count();
+        if audiobook_count > 1 {
+            skipped_items.push(SkippedItem {
+                title: title.to_string(),
+                author: author_name.to_string(),
+                reason: format!("Multi-file audiobook ({audiobook_count} files)"),
+            });
+            files_to_skip += audiobook_count as i64;
+            // Still count non-audiobook files for this book.
+            let non_audio: Vec<_> = file_list
+                .iter()
+                .filter(|f| {
+                    let qid = extract_quality_id(f);
+                    resolve_media_type(qid, &f.path) != Some(MediaType::Audiobook)
+                })
+                .collect();
+            for f in &non_audio {
+                let qid = extract_quality_id(f);
+                if resolve_media_type(qid, &f.path).is_none() {
+                    files_to_skip += 1;
+                    skipped_items.push(SkippedItem {
+                        title: title.to_string(),
+                        author: author_name.to_string(),
+                        reason: format!("Unknown format: {}", f.path),
+                    });
+                } else {
+                    let dest = build_dest_path(&livrarr_root.path, author_name, title, &f.path);
+                    if dest.exists() {
+                        files_to_skip += 1;
+                        skipped_items.push(SkippedItem {
+                            title: title.to_string(),
+                            author: author_name.to_string(),
+                            reason: "Destination already exists".to_string(),
+                        });
+                    } else {
+                        files_to_import += 1;
+                    }
+                }
+            }
+        } else {
+            // Process each file individually.
+            for f in &file_list {
+                let qid = extract_quality_id(f);
+                if resolve_media_type(qid, &f.path).is_none() {
+                    files_to_skip += 1;
+                    skipped_items.push(SkippedItem {
+                        title: title.to_string(),
+                        author: author_name.to_string(),
+                        reason: format!("Unknown format: {}", f.path),
+                    });
+                    continue;
+                }
+                let dest = build_dest_path(&livrarr_root.path, author_name, title, &f.path);
+                if dest.exists() {
+                    files_to_skip += 1;
+                    skipped_items.push(SkippedItem {
+                        title: title.to_string(),
+                        author: author_name.to_string(),
+                        reason: "Destination already exists".to_string(),
+                    });
+                } else {
+                    files_to_import += 1;
+                }
+            }
+        }
+
+        // Work dedup: ISBN/ASIN first, then author+title+year.
+        let edition = book.monitored_edition();
+        let isbn = edition
+            .and_then(|e| e.isbn13.as_deref())
+            .filter(|s| !s.is_empty());
+        let asin = edition
+            .and_then(|e| e.asin.as_deref())
+            .filter(|s| !s.is_empty());
+        let year = book.release_date.as_deref().and_then(extract_year);
+
+        let is_existing = if let Some(isbn_val) = isbn {
+            existing_works
+                .iter()
+                .any(|w| w.isbn_13.as_deref() == Some(isbn_val))
+        } else if let Some(asin_val) = asin {
+            existing_works
+                .iter()
+                .any(|w| w.asin.as_deref() == Some(asin_val))
+        } else {
+            // author+title+year match
+            let norm_title = normalize_for_matching(title);
+            existing_works.iter().any(|w| {
+                normalize_for_matching(&w.author_name) == norm_author
+                    && normalize_for_matching(&w.title) == norm_title
+                    && w.year == year
+            })
+        };
+
+        if is_existing {
+            works_existing += 1;
+        } else {
+            works_to_create += 1;
+        }
+    }
+
+    // Count existing authors that were referenced by Readarr books.
+    let authors_existing = authors
+        .iter()
+        .filter(|a| {
+            let name = a.author_name.as_deref().unwrap_or("");
+            let norm = normalize_for_matching(name);
+            author_names_seen.get(&norm) == Some(&true)
+        })
+        .count() as i64;
+
+    Ok(Json(PreviewResponse {
+        authors_to_create,
+        authors_existing,
+        works_to_create,
+        works_existing,
+        files_to_import,
+        files_to_skip,
+        skipped_items,
+    }))
+}
+
+/// POST /api/v1/import/readarr/start
+pub async fn start(
+    State(state): State<AppState>,
+    auth: AuthContext,
+    Json(req): Json<StartRequest>,
+) -> Result<Json<StartResponse>, ApiError> {
+    let user_id = auth.user.id;
+    let import_id = uuid::Uuid::new_v4().to_string();
+
+    // Create import record — will fail if user already has a running import
+    // (due to partial unique index).
+    state
+        .db
+        .create_import(CreateImportDbRequest {
+            id: import_id.clone(),
+            user_id,
+            source: "readarr".to_string(),
+            source_url: Some(req.url.clone()),
+            target_root_folder_id: Some(req.livrarr_root_folder_id),
+        })
+        .await
+        .map_err(|e| match e {
+            livrarr_domain::DbError::Constraint { .. } => ApiError::Conflict {
+                reason: "An import is already running for this user".to_string(),
+            },
+            other => ApiError::from(other),
+        })?;
+
+    // Set initial progress.
+    {
+        let mut prog = state.readarr_import_progress.lock().await;
+        *prog = ImportProgress {
+            running: true,
+            import_id: Some(import_id.clone()),
+            phase: "fetching".to_string(),
+            ..Default::default()
+        };
+    }
+
+    // Spawn background task.
+    let state2 = state.clone();
+    let import_id2 = import_id.clone();
+    let url = req.url.clone();
+    let api_key = req.api_key.clone();
+    let readarr_root_id = req.readarr_root_folder_id;
+    let livrarr_root_id = req.livrarr_root_folder_id;
+
+    tokio::spawn(async move {
+        if let Err(e) = run_import(
+            state2.clone(),
+            user_id,
+            &import_id2,
+            &url,
+            &api_key,
+            readarr_root_id,
+            livrarr_root_id,
+        )
+        .await
+        {
+            error!(import_id = %import_id2, "Readarr import failed: {e}");
+            let _ = state2.db.update_import_status(&import_id2, "failed").await;
+        }
+
+        // Clear progress.
+        let mut prog = state2.readarr_import_progress.lock().await;
+        prog.running = false;
+        prog.phase = "done".to_string();
+    });
+
+    Ok(Json(StartResponse { import_id }))
+}
+
+/// GET /api/v1/import/readarr/progress
+pub async fn progress(
+    State(state): State<AppState>,
+    _auth: AuthContext,
+) -> Result<Json<ImportProgress>, ApiError> {
+    let prog = state.readarr_import_progress.lock().await;
+    Ok(Json(prog.clone()))
+}
+
+/// GET /api/v1/import/readarr/history
+pub async fn history(
+    State(state): State<AppState>,
+    auth: AuthContext,
+) -> Result<Json<ImportHistoryResponse>, ApiError> {
+    let imports = state.db.list_imports(auth.user.id).await?;
+    let records = imports.iter().map(import_to_record).collect();
+    Ok(Json(ImportHistoryResponse { imports: records }))
+}
+
+/// DELETE /api/v1/import/readarr/{import_id}
+pub async fn undo(
+    State(state): State<AppState>,
+    auth: AuthContext,
+    AxumPath(import_id): AxumPath<String>,
+) -> Result<Json<UndoResponse>, ApiError> {
+    let user_id = auth.user.id;
+
+    // Verify import exists and belongs to user.
+    let imp = state
+        .db
+        .get_import(&import_id)
+        .await?
+        .ok_or(ApiError::NotFound)?;
+
+    if imp.user_id != user_id {
+        return Err(ApiError::Forbidden);
+    }
+
+    if imp.status == "running" {
+        return Err(ApiError::BadRequest(
+            "Cannot undo a running import. Wait for it to complete.".into(),
+        ));
+    }
+
+    // 1. Query all library items with this import_id.
+    let items = state.db.list_library_items_by_import(&import_id).await?;
+
+    let mut files_deleted = 0i64;
+    let mut files_skipped = 0i64;
+
+    // 2. For each item, try to delete the destination file.
+    for item in &items {
+        let path = Path::new(&item.path);
+        if path.exists() {
+            // Conservative: check file size matches.
+            match std::fs::metadata(path) {
+                Ok(meta) => {
+                    if meta.len() as i64 == item.file_size {
+                        match std::fs::remove_file(path) {
+                            Ok(()) => {
+                                files_deleted += 1;
+                                info!(path = %item.path, "Undo: deleted file");
+                            }
+                            Err(e) => {
+                                warn!(path = %item.path, "Undo: failed to delete file: {e}");
+                                files_skipped += 1;
+                            }
+                        }
+                    } else {
+                        warn!(
+                            path = %item.path,
+                            expected = item.file_size,
+                            actual = meta.len(),
+                            "Undo: skipping file with size mismatch"
+                        );
+                        files_skipped += 1;
+                    }
+                }
+                Err(e) => {
+                    warn!(path = %item.path, "Undo: cannot stat file: {e}");
+                    files_skipped += 1;
+                }
+            }
+        }
+
+        // 3. Delete the library item DB row regardless of file deletion outcome.
+        if let Err(e) = state.db.delete_library_item_by_id(item.id).await {
+            warn!(id = item.id, "Undo: failed to delete library item: {e}");
+        }
+    }
+
+    // 4. Delete orphan works (import_id match, zero library items).
+    let works_deleted = state
+        .db
+        .delete_orphan_works_by_import(&import_id)
+        .await
+        .unwrap_or(0);
+
+    // 5. Delete orphan authors (import_id match, zero works).
+    let authors_deleted = state
+        .db
+        .delete_orphan_authors_by_import(&import_id)
+        .await
+        .unwrap_or(0);
+
+    // 6. Mark import as undone.
+    state.db.update_import_status(&import_id, "undone").await?;
+
+    Ok(Json(UndoResponse {
+        files_deleted,
+        files_skipped,
+        works_deleted,
+        authors_deleted,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Fetch helpers
+// ---------------------------------------------------------------------------
+
+async fn fetch_all_readarr_data(
+    client: &ReadarrClient,
+) -> Result<
+    (
+        Vec<RdAuthor>,
+        Vec<RdBook>,
+        Vec<RdBookFile>,
+        Vec<RdRootFolder>,
+    ),
+    ApiError,
+> {
+    // Fetch all data before any mutations.
+    let folders = client
+        .root_folders()
+        .await
+        .map_err(|e| ApiError::BadGateway(format!("Readarr root folders: {e}")))?;
+    let authors = client
+        .authors()
+        .await
+        .map_err(|e| ApiError::BadGateway(format!("Readarr authors: {e}")))?;
+    let books = client
+        .books()
+        .await
+        .map_err(|e| ApiError::BadGateway(format!("Readarr books: {e}")))?;
+    let book_files = client
+        .book_files()
+        .await
+        .map_err(|e| ApiError::BadGateway(format!("Readarr book files: {e}")))?;
+
+    Ok((authors, books, book_files, folders))
+}
+
+// ---------------------------------------------------------------------------
+// Import execution
+// ---------------------------------------------------------------------------
+
+async fn run_import(
+    state: AppState,
+    user_id: i64,
+    import_id: &str,
+    url: &str,
+    api_key: &str,
+    readarr_root_id: i64,
+    livrarr_root_id: i64,
+) -> Result<(), String> {
+    // Phase 1: Fetch.
+    let client = ReadarrClient::new(url, api_key, state.http_client_safe.inner().clone());
+    let (rd_authors, rd_books, rd_book_files, rd_folders) =
+        fetch_all_readarr_data(&client)
+            .await
+            .map_err(|e| format!("fetch failed: {e}"))?;
+
+    let readarr_root = rd_folders
+        .iter()
+        .find(|f| f.id == readarr_root_id)
+        .map(|f| f.path.clone())
+        .ok_or_else(|| "Invalid Readarr root folder ID".to_string())?;
+
+    let livrarr_root = state
+        .db
+        .get_root_folder(livrarr_root_id)
+        .await
+        .map_err(|e| format!("get livrarr root folder: {e}"))?;
+
+    // Build maps.
+    let author_map: HashMap<i64, &RdAuthor> = rd_authors.iter().map(|a| (a.id, a)).collect();
+    let mut book_files_by_book: HashMap<i64, Vec<&RdBookFile>> = HashMap::new();
+    for bf in &rd_book_files {
+        book_files_by_book.entry(bf.book_id).or_default().push(bf);
+    }
+
+    // Load existing data for dedup.
+    let existing_authors = state
+        .db
+        .list_authors(user_id)
+        .await
+        .map_err(|e| format!("list authors: {e}"))?;
+    // Update progress.
+    {
+        let mut prog = state.readarr_import_progress.lock().await;
+        prog.phase = "processing".to_string();
+        prog.authors_total = rd_authors.len() as i64;
+        prog.works_total = rd_books.len() as i64;
+        prog.files_total = rd_book_files.len() as i64;
+    }
+
+    // Phase 2: Process authors.
+    // Map Readarr author ID -> Livrarr author ID.
+    let mut rd_to_livrarr_author: HashMap<i64, i64> = HashMap::new();
+    let mut authors_created = 0i64;
+
+    for rd_author in &rd_authors {
+        let name = rd_author.author_name.as_deref().unwrap_or("").trim();
+        if name.is_empty() {
+            continue;
+        }
+
+        let norm = normalize_for_matching(name);
+
+        // Conservative: only merge if exactly one name match.
+        let matches: Vec<_> = existing_authors
+            .iter()
+            .filter(|a| normalize_for_matching(&a.name) == norm)
+            .collect();
+
+        let livrarr_author_id = if matches.len() == 1 {
+            matches[0].id
+        } else {
+            // Create new author.
+            let sort_name = rd_author
+                .sort_name
+                .as_deref()
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| derive_sort_name(name));
+
+            match state
+                .db
+                .create_author(CreateAuthorDbRequest {
+                    user_id,
+                    name: name.to_string(),
+                    sort_name: Some(sort_name),
+                    ol_key: None,
+                    gr_key: rd_author.foreign_author_id.clone(),
+                    hc_key: None,
+                    import_id: Some(import_id.to_string()),
+                })
+                .await
+            {
+                Ok(a) => {
+                    authors_created += 1;
+                    a.id
+                }
+                Err(e) => {
+                    warn!(name = %name, "Failed to create author: {e}");
+                    let mut prog = state.readarr_import_progress.lock().await;
+                    prog.errors.push(format!("Author '{name}': {e}"));
+                    continue;
+                }
+            }
+        };
+
+        rd_to_livrarr_author.insert(rd_author.id, livrarr_author_id);
+
+        {
+            let mut prog = state.readarr_import_progress.lock().await;
+            prog.authors_processed += 1;
+        }
+    }
+
+    // Phase 3: Process books/works.
+    // Map Readarr book ID -> Livrarr work ID.
+    let mut rd_to_livrarr_work: HashMap<i64, i64> = HashMap::new();
+    let mut works_created = 0i64;
+    let mut files_imported = 0i64;
+    let mut files_skipped = 0i64;
+
+    // Refresh existing works to include newly created ones.
+    let all_works = state
+        .db
+        .list_works(user_id)
+        .await
+        .map_err(|e| format!("list works after authors: {e}"))?;
+
+    for rd_book in &rd_books {
+        let rd_author_id = rd_book.author_id;
+        let author_name = author_map
+            .get(&rd_author_id)
+            .and_then(|a| a.author_name.as_deref())
+            .unwrap_or("");
+        let title = rd_book.title.as_deref().unwrap_or("").trim();
+
+        // Skip books with no author.
+        if author_name.is_empty() {
+            let mut prog = state.readarr_import_progress.lock().await;
+            prog.works_processed += 1;
+            prog.errors
+                .push(format!("Book '{title}': skipped (no author)"));
+            continue;
+        }
+
+        let livrarr_author_id = rd_to_livrarr_author.get(&rd_author_id).copied();
+
+        // Edition metadata.
+        let edition = rd_book.monitored_edition();
+        let isbn = edition
+            .and_then(|e| e.isbn13.as_deref())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+        let asin = edition
+            .and_then(|e| e.asin.as_deref())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+        let publisher = edition
+            .and_then(|e| e.publisher.as_deref())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+        let language = edition
+            .and_then(|e| e.language.as_deref())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+        let year = rd_book.release_date.as_deref().and_then(extract_year);
+
+        // Dedup: ISBN/ASIN first, then author+title+year.
+        let norm_title = normalize_for_matching(title);
+        let norm_author = normalize_for_matching(author_name);
+
+        let existing_work = if let Some(ref isbn_val) = isbn {
+            all_works
+                .iter()
+                .find(|w| w.isbn_13.as_deref() == Some(isbn_val))
+        } else if let Some(ref asin_val) = asin {
+            all_works
+                .iter()
+                .find(|w| w.asin.as_deref() == Some(asin_val))
+        } else {
+            all_works.iter().find(|w| {
+                normalize_for_matching(&w.author_name) == norm_author
+                    && normalize_for_matching(&w.title) == norm_title
+                    && w.year == year
+            })
+        };
+
+        let work_id = if let Some(ew) = existing_work {
+            // Merge into existing — only add library items, never update metadata.
+            ew.id
+        } else {
+            // Create new work.
+            let description = rd_book
+                .overview
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .or_else(|| {
+                    edition
+                        .and_then(|e| e.overview.as_deref())
+                        .filter(|s| !s.is_empty())
+                })
+                .map(|s| s.to_string());
+
+            let (series_name, series_position) = rd_book
+                .series_title
+                .as_deref()
+                .map(parse_series_title)
+                .unwrap_or((None, None));
+
+            let genres = rd_book.genres.clone();
+            let page_count = rd_book
+                .page_count
+                .or_else(|| edition.and_then(|e| e.page_count));
+
+            let rating = rd_book.ratings.as_ref().and_then(|r| r.value);
+            let rating_count = rd_book.ratings.as_ref().and_then(|r| r.votes);
+
+            let cover_url = extract_cover_url(&rd_book.images);
+
+            // Check if this book has any files to determine monitor flags.
+            let book_files_list = book_files_by_book.get(&rd_book.id);
+            let has_ebook_file = book_files_list
+                .map(|fs| {
+                    fs.iter().any(|f| {
+                        resolve_media_type(extract_quality_id(f), &f.path) == Some(MediaType::Ebook)
+                    })
+                })
+                .unwrap_or(false);
+            let has_audiobook_file = book_files_list
+                .map(|fs| {
+                    fs.iter().any(|f| {
+                        resolve_media_type(extract_quality_id(f), &f.path)
+                            == Some(MediaType::Audiobook)
+                    })
+                })
+                .unwrap_or(false);
+
+            // If no files, use Readarr monitored state.
+            let monitor_ebook = has_ebook_file || rd_book.monitored.unwrap_or(false);
+            let monitor_audiobook = has_audiobook_file;
+
+            match state
+                .db
+                .create_work(CreateWorkDbRequest {
+                    user_id,
+                    title: title.to_string(),
+                    author_name: author_name.to_string(),
+                    author_id: livrarr_author_id,
+                    ol_key: None,
+                    gr_key: rd_book.foreign_book_id.clone(),
+                    year,
+                    cover_url,
+                    metadata_source: Some("readarr".to_string()),
+                    detail_url: None,
+                    language,
+                    import_id: Some(import_id.to_string()),
+                })
+                .await
+            {
+                Ok(w) => {
+                    works_created += 1;
+
+                    // Set enrichment status to skipped, plus all the extra fields.
+                    // We use update_work_enrichment to fill in the rest.
+                    let _ = state
+                        .db
+                        .update_work_enrichment(
+                            user_id,
+                            w.id,
+                            livrarr_db::UpdateWorkEnrichmentDbRequest {
+                                title: None,
+                                subtitle: None,
+                                original_title: None,
+                                author_name: None,
+                                description,
+                                year: None,
+                                series_name,
+                                series_position,
+                                genres,
+                                language: None,
+                                page_count,
+                                duration_seconds: None,
+                                publisher,
+                                publish_date: rd_book.release_date.clone(),
+                                hc_key: None,
+                                isbn_13: isbn.clone(),
+                                asin: asin.clone(),
+                                narrator: None,
+                                narration_type: None,
+                                abridged: None,
+                                rating,
+                                rating_count,
+                                enrichment_status: livrarr_domain::EnrichmentStatus::Skipped,
+                                enrichment_source: Some("readarr".to_string()),
+                                cover_url: None,
+                            },
+                        )
+                        .await;
+
+                    // Set monitor flags.
+                    let _ = state
+                        .db
+                        .update_work_user_fields(
+                            user_id,
+                            w.id,
+                            livrarr_db::UpdateWorkUserFieldsDbRequest {
+                                title: None,
+                                author_name: None,
+                                series_name: None,
+                                series_position: None,
+                                monitor_ebook: Some(monitor_ebook),
+                                monitor_audiobook: Some(monitor_audiobook),
+                            },
+                        )
+                        .await;
+
+                    w.id
+                }
+                Err(e) => {
+                    warn!(title = %title, "Failed to create work: {e}");
+                    let mut prog = state.readarr_import_progress.lock().await;
+                    prog.works_processed += 1;
+                    prog.errors.push(format!("Work '{title}': {e}"));
+                    continue;
+                }
+            }
+        };
+
+        rd_to_livrarr_work.insert(rd_book.id, work_id);
+
+        {
+            let mut prog = state.readarr_import_progress.lock().await;
+            prog.works_processed += 1;
+        }
+    }
+
+    // Phase 4: Process files.
+    for rd_file in &rd_book_files {
+        let work_id = match rd_to_livrarr_work.get(&rd_file.book_id) {
+            Some(id) => *id,
+            None => {
+                // Book was skipped.
+                files_skipped += 1;
+                let mut prog = state.readarr_import_progress.lock().await;
+                prog.files_processed += 1;
+                prog.files_skipped += 1;
+                continue;
+            }
+        };
+
+        let author_name = rd_file
+            .author_id
+            .and_then(|aid| author_map.get(&aid))
+            .and_then(|a| a.author_name.as_deref())
+            .unwrap_or("Unknown Author");
+
+        let title = rd_books
+            .iter()
+            .find(|b| b.id == rd_file.book_id)
+            .and_then(|b| b.title.as_deref())
+            .unwrap_or("Unknown Title");
+
+        // Determine media type.
+        let qid = extract_quality_id(rd_file);
+        let media_type = match resolve_media_type(qid, &rd_file.path) {
+            Some(mt) => mt,
+            None => {
+                files_skipped += 1;
+                let mut prog = state.readarr_import_progress.lock().await;
+                prog.files_processed += 1;
+                prog.files_skipped += 1;
+                continue;
+            }
+        };
+
+        // Multi-file audiobook check.
+        if media_type == MediaType::Audiobook {
+            let book_audio_count = book_files_by_book
+                .get(&rd_file.book_id)
+                .map(|fs| {
+                    fs.iter()
+                        .filter(|f| {
+                            resolve_media_type(extract_quality_id(f), &f.path)
+                                == Some(MediaType::Audiobook)
+                        })
+                        .count()
+                })
+                .unwrap_or(0);
+            if book_audio_count > 1 {
+                files_skipped += 1;
+                let mut prog = state.readarr_import_progress.lock().await;
+                prog.files_processed += 1;
+                prog.files_skipped += 1;
+                continue;
+            }
+        }
+
+        // Validate source path.
+        let source = match validate_source_path(&rd_file.path, &readarr_root) {
+            Ok(p) => p,
+            Err(e) => {
+                warn!(path = %rd_file.path, "Source path validation failed: {e}");
+                files_skipped += 1;
+                let mut prog = state.readarr_import_progress.lock().await;
+                prog.files_processed += 1;
+                prog.files_skipped += 1;
+                prog.errors.push(format!("File '{}': {e}", rd_file.path));
+                continue;
+            }
+        };
+
+        // Build destination path.
+        let dest = build_dest_path(&livrarr_root.path, author_name, title, &rd_file.path);
+
+        // Check if destination already exists.
+        if dest.exists() {
+            files_skipped += 1;
+            let mut prog = state.readarr_import_progress.lock().await;
+            prog.files_processed += 1;
+            prog.files_skipped += 1;
+            continue;
+        }
+
+        // Materialize file (hardlink or copy).
+        if let Err(e) = materialize_file(&source, &dest) {
+            warn!(src = %rd_file.path, dest = %dest.display(), "File materialization failed: {e}");
+            files_skipped += 1;
+            let mut prog = state.readarr_import_progress.lock().await;
+            prog.files_processed += 1;
+            prog.files_skipped += 1;
+            prog.errors.push(format!("File '{}': {e}", rd_file.path));
+            continue;
+        }
+
+        // Get the relative path from root folder.
+        let rel_path = dest
+            .strip_prefix(&livrarr_root.path)
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|_| dest.to_string_lossy().to_string());
+
+        // Create library item.
+        match state
+            .db
+            .create_library_item(CreateLibraryItemDbRequest {
+                user_id,
+                work_id,
+                root_folder_id: livrarr_root_id,
+                path: rel_path,
+                media_type,
+                file_size: rd_file.size,
+                import_id: Some(import_id.to_string()),
+            })
+            .await
+        {
+            Ok(_) => {
+                files_imported += 1;
+            }
+            Err(e) => {
+                warn!(path = %rd_file.path, "Failed to create library item: {e}");
+                // File was created but DB row failed — leave file in place.
+                files_skipped += 1;
+                let mut prog = state.readarr_import_progress.lock().await;
+                prog.errors
+                    .push(format!("LibraryItem for '{}': {e}", rd_file.path));
+            }
+        }
+
+        {
+            let mut prog = state.readarr_import_progress.lock().await;
+            prog.files_processed += 1;
+        }
+    }
+
+    // Update counters and mark completed.
+    let _ = state
+        .db
+        .update_import_counts(
+            import_id,
+            authors_created,
+            works_created,
+            files_imported,
+            files_skipped,
+        )
+        .await;
+
+    state
+        .db
+        .set_import_completed(import_id)
+        .await
+        .map_err(|e| format!("set completed: {e}"))?;
+
+    info!(
+        import_id = %import_id,
+        authors_created,
+        works_created,
+        files_imported,
+        files_skipped,
+        "Readarr import completed"
+    );
+
+    Ok(())
+}

--- a/crates/livrarr-server/src/handlers/root_folder.rs
+++ b/crates/livrarr-server/src/handlers/root_folder.rs
@@ -211,6 +211,7 @@ pub async fn scan(
                             path: relative_str,
                             media_type,
                             file_size,
+                            import_id: None,
                         })
                         .await
                     {

--- a/crates/livrarr-server/src/handlers/work.rs
+++ b/crates/livrarr-server/src/handlers/work.rs
@@ -803,6 +803,7 @@ pub async fn add_work_internal(
                     ol_key: req.author_ol_key.clone(),
                     gr_key: None,
                     hc_key: None,
+                    import_id: None,
                 })
                 .await?;
             crate::handlers::author::spawn_bibliography_fetch((*state).clone(), author.id, user_id);
@@ -829,6 +830,7 @@ pub async fn add_work_internal(
             metadata_source: req.metadata_source,
             detail_url,
             language: req.language,
+            import_id: None,
         })
         .await?;
 

--- a/crates/livrarr-server/src/jobs.rs
+++ b/crates/livrarr-server/src/jobs.rs
@@ -1050,6 +1050,7 @@ pub async fn author_monitor_tick(state: AppState, cancel: CancellationToken) -> 
                             metadata_source: None,
                             detail_url: None,
                             language: None,
+                            import_id: None,
                         })
                         .await
                     {

--- a/crates/livrarr-server/src/lib.rs
+++ b/crates/livrarr-server/src/lib.rs
@@ -13,6 +13,7 @@ pub mod handlers;
 pub mod jobs;
 pub mod matching;
 pub mod middleware;
+pub mod readarr_client;
 pub mod router;
 pub mod state;
 

--- a/crates/livrarr-server/src/main.rs
+++ b/crates/livrarr-server/src/main.rs
@@ -142,6 +142,9 @@ async fn main() {
         grab_search_cache: Arc::new(livrarr_server::state::GrabSearchCache::new()),
         rss_last_run: Arc::new(std::sync::atomic::AtomicI64::new(0)),
         rss_sync_running: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        readarr_import_progress: Arc::new(tokio::sync::Mutex::new(
+            livrarr_server::handlers::readarr_import::ImportProgress::default(),
+        )),
     };
 
     // Step 7: Startup recovery — reset stale state from unclean shutdown (JOBS-003).

--- a/crates/livrarr-server/src/readarr_client.rs
+++ b/crates/livrarr-server/src/readarr_client.rs
@@ -1,0 +1,231 @@
+//! Readarr API client for library import.
+//!
+//! Lightweight client that fetches authors, books, editions, and book files
+//! from a Readarr instance via its REST API.
+
+use reqwest::Client;
+use serde::Deserialize;
+
+/// Readarr API client.
+pub struct ReadarrClient {
+    base_url: String,
+    api_key: String,
+    http: Client,
+}
+
+impl ReadarrClient {
+    pub fn new(url: &str, api_key: &str, http: Client) -> Self {
+        let base_url = url.trim_end_matches('/').to_string();
+        Self {
+            base_url,
+            api_key: api_key.to_string(),
+            http,
+        }
+    }
+
+    async fn get<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T, ReadarrError> {
+        let url = format!("{}{}", self.base_url, path);
+        let resp = self
+            .http
+            .get(&url)
+            .header("X-Api-Key", &self.api_key)
+            .timeout(std::time::Duration::from_secs(30))
+            .send()
+            .await
+            .map_err(|e| ReadarrError::Network(e.to_string()))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(ReadarrError::Api {
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        resp.json::<T>()
+            .await
+            .map_err(|e| ReadarrError::Parse(e.to_string()))
+    }
+
+    pub async fn root_folders(&self) -> Result<Vec<RdRootFolder>, ReadarrError> {
+        self.get("/api/v1/rootfolder").await
+    }
+
+    pub async fn authors(&self) -> Result<Vec<RdAuthor>, ReadarrError> {
+        self.get("/api/v1/author").await
+    }
+
+    pub async fn books(&self) -> Result<Vec<RdBook>, ReadarrError> {
+        self.get("/api/v1/book").await
+    }
+
+    pub async fn book_files(&self) -> Result<Vec<RdBookFile>, ReadarrError> {
+        self.get("/api/v1/bookfile").await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub enum ReadarrError {
+    Network(String),
+    Api { status: u16, body: String },
+    Parse(String),
+}
+
+impl std::fmt::Display for ReadarrError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Network(e) => write!(f, "network error: {e}"),
+            Self::Api { status, body } => write!(f, "API error {status}: {body}"),
+            Self::Parse(e) => write!(f, "parse error: {e}"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Response types — lightweight deserialization structs
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RdRootFolder {
+    pub id: i64,
+    pub name: Option<String>,
+    pub path: String,
+    pub accessible: Option<bool>,
+    pub free_space: Option<i64>,
+    pub total_space: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RdAuthor {
+    pub id: i64,
+    pub author_name: Option<String>,
+    pub sort_name: Option<String>,
+    pub foreign_author_id: Option<String>,
+    pub overview: Option<String>,
+    pub genres: Option<Vec<String>>,
+    pub images: Option<Vec<RdImage>>,
+    pub monitored: Option<bool>,
+    pub added: Option<String>,
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RdBook {
+    pub id: i64,
+    pub title: Option<String>,
+    pub author_id: i64,
+    pub foreign_book_id: Option<String>,
+    pub series_title: Option<String>,
+    pub overview: Option<String>,
+    pub release_date: Option<String>,
+    pub page_count: Option<i32>,
+    pub genres: Option<Vec<String>>,
+    pub ratings: Option<RdRatings>,
+    pub images: Option<Vec<RdImage>>,
+    pub monitored: Option<bool>,
+    pub added: Option<String>,
+    pub editions: Option<Vec<RdEdition>>,
+}
+
+impl RdBook {
+    /// Returns the monitored edition, or the first edition if none is monitored.
+    pub fn monitored_edition(&self) -> Option<&RdEdition> {
+        let editions = self.editions.as_ref()?;
+        editions
+            .iter()
+            .find(|e| e.monitored.unwrap_or(false))
+            .or_else(|| editions.first())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RdEdition {
+    pub id: i64,
+    pub book_id: Option<i64>,
+    pub foreign_edition_id: Option<String>,
+    pub isbn13: Option<String>,
+    pub asin: Option<String>,
+    pub title: Option<String>,
+    pub language: Option<String>,
+    pub overview: Option<String>,
+    pub format: Option<String>,
+    pub is_ebook: Option<bool>,
+    pub publisher: Option<String>,
+    pub page_count: Option<i32>,
+    pub release_date: Option<String>,
+    pub images: Option<Vec<RdImage>>,
+    pub monitored: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RdBookFile {
+    pub id: i64,
+    pub author_id: Option<i64>,
+    pub book_id: i64,
+    pub path: String,
+    pub size: i64,
+    pub date_added: Option<String>,
+    pub quality: Option<RdQuality>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RdQuality {
+    pub quality: Option<RdQualityInner>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RdQualityInner {
+    pub id: i32,
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RdRatings {
+    pub votes: Option<i32>,
+    pub value: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RdImage {
+    pub url: Option<String>,
+    pub cover_type: Option<String>,
+    pub remote_url: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Map a Readarr quality ID to a Livrarr MediaType string.
+/// Returns None for Unknown(0) — caller should infer from file extension.
+pub fn quality_to_media_type(quality_id: i32) -> Option<&'static str> {
+    match quality_id {
+        1..=4 => Some("ebook"),       // PDF, MOBI, EPUB, AZW3
+        10..=13 => Some("audiobook"), // MP3, FLAC, M4B, UnknownAudio
+        _ => None,                    // Unknown(0) or unrecognized
+    }
+}
+
+/// Infer media type from file extension when quality is Unknown.
+pub fn media_type_from_extension(path: &str) -> Option<&'static str> {
+    let ext = path.rsplit('.').next()?.to_lowercase();
+    match ext.as_str() {
+        "epub" | "mobi" | "azw" | "azw3" | "pdf" | "cbz" | "cbr" => Some("ebook"),
+        "mp3" | "m4b" | "m4a" | "flac" | "ogg" | "wma" | "aac" => Some("audiobook"),
+        _ => None,
+    }
+}

--- a/crates/livrarr-server/src/router.rs
+++ b/crates/livrarr-server/src/router.rs
@@ -233,6 +233,31 @@ pub fn build_router(state: AppState, ui_dir: std::path::PathBuf) -> Router {
             "/manualimport/search",
             post(handlers::manual_import::search),
         )
+        // Readarr import
+        .route(
+            "/import/readarr/connect",
+            post(handlers::readarr_import::connect),
+        )
+        .route(
+            "/import/readarr/preview",
+            post(handlers::readarr_import::preview),
+        )
+        .route(
+            "/import/readarr/start",
+            post(handlers::readarr_import::start),
+        )
+        .route(
+            "/import/readarr/progress",
+            get(handlers::readarr_import::progress),
+        )
+        .route(
+            "/import/readarr/history",
+            get(handlers::readarr_import::history),
+        )
+        .route(
+            "/import/readarr/{import_id}",
+            delete(handlers::readarr_import::undo),
+        )
         // Library files
         .route("/workfile", get(handlers::workfile::list))
         .route(

--- a/crates/livrarr-server/src/state.rs
+++ b/crates/livrarr-server/src/state.rs
@@ -39,6 +39,9 @@ pub struct AppState {
     pub rss_last_run: Arc<std::sync::atomic::AtomicI64>,
     /// Guard against concurrent RSS sync runs.
     pub rss_sync_running: Arc<std::sync::atomic::AtomicBool>,
+    /// Readarr import progress — polled by frontend.
+    pub readarr_import_progress:
+        Arc<tokio::sync::Mutex<crate::handlers::readarr_import::ImportProgress>>,
 }
 
 /// Per-(user, work) mutex map for serializing concurrent imports of the same work.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,9 @@ const ManualImportPage = lazy(
   () => import("@/pages/manual-import/ManualImportPage"),
 );
 const MissingPage = lazy(() => import("@/pages/wanted/MissingPage"));
+const ReadarrImportPage = lazy(
+  () => import("@/pages/import/ReadarrImportPage"),
+);
 
 // Settings (lazy)
 const MediaManagementPage = lazy(
@@ -167,6 +170,14 @@ export function App() {
                 element={
                   <LazyPage>
                     <ManualImportPage />
+                  </LazyPage>
+                }
+              />
+              <Route
+                path="import/readarr"
+                element={
+                  <LazyPage>
+                    <ReadarrImportPage />
                   </LazyPage>
                 }
               />

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -65,6 +65,10 @@ import type {
   ManualImportItem,
   ManualImportResponse,
   PaginatedResponse,
+  ReadarrRootFolder,
+  ImportPreviewResponse,
+  ImportProgressResponse,
+  ImportHistoryItem,
 } from "@/types/api";
 
 // Setup
@@ -431,3 +435,36 @@ export const executeManualImport = (items: ManualImportItem[]) =>
     method: "POST",
     body: JSON.stringify({ items }),
   });
+
+// Readarr Import
+export const readarrConnect = (url: string, apiKey: string) =>
+  apiFetch<ReadarrRootFolder[]>("/import/readarr/connect", {
+    method: "POST",
+    body: JSON.stringify({ url, apiKey }),
+  });
+export const readarrPreview = (req: {
+  url: string;
+  apiKey: string;
+  readarrRootFolderId: number;
+  livrarrRootFolderId: number;
+}) =>
+  apiFetch<ImportPreviewResponse>("/import/readarr/preview", {
+    method: "POST",
+    body: JSON.stringify(req),
+  });
+export const readarrStartImport = (req: {
+  url: string;
+  apiKey: string;
+  readarrRootFolderId: number;
+  livrarrRootFolderId: number;
+}) =>
+  apiFetch<{ importId: string }>("/import/readarr/start", {
+    method: "POST",
+    body: JSON.stringify(req),
+  });
+export const readarrProgress = () =>
+  apiFetch<ImportProgressResponse>("/import/readarr/progress");
+export const readarrHistory = () =>
+  apiFetch<ImportHistoryItem[]>("/import/readarr/history");
+export const readarrUndo = (importId: string) =>
+  apiFetch<void>(`/import/readarr/${importId}`, { method: "DELETE" });

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -90,6 +90,11 @@ const navGroups: NavGroup[] = [
         path: "/import",
         icon: <Import size={18} />,
       },
+      {
+        label: "Readarr Import",
+        path: "/import/readarr",
+        icon: <Download size={18} />,
+      },
     ],
   },
   {

--- a/frontend/src/pages/import/ReadarrImportPage.tsx
+++ b/frontend/src/pages/import/ReadarrImportPage.tsx
@@ -1,0 +1,600 @@
+import { useState, useEffect } from "react";
+import { Link } from "react-router";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  Loader2,
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  CheckCircle2,
+  XCircle,
+  Undo2,
+  ExternalLink,
+  Info,
+} from "lucide-react";
+import { PageContent } from "@/components/Page/PageContent";
+import { PageToolbar } from "@/components/Page/PageToolbar";
+import { ConfirmModal } from "@/components/Page/ConfirmModal";
+import * as api from "@/api";
+import { formatBytes, formatRelativeDate } from "@/utils/format";
+import { cn } from "@/utils/cn";
+import type {
+  ReadarrRootFolder,
+  ImportPreviewResponse,
+  ImportProgressResponse,
+  ImportHistoryItem,
+} from "@/types/api";
+
+type Phase =
+  | "idle"
+  | "connecting"
+  | "connected"
+  | "previewing"
+  | "previewed"
+  | "importing"
+  | "completed"
+  | "failed";
+
+export default function ReadarrImportPage() {
+  const queryClient = useQueryClient();
+
+  // Connection form
+  const [url, setUrl] = useState("");
+  const [apiKey, setApiKey] = useState("");
+
+  // State machine
+  const [phase, setPhase] = useState<Phase>("idle");
+
+  // Connected state
+  const [readarrFolders, setReadarrFolders] = useState<ReadarrRootFolder[]>([]);
+  const [selectedReadarrFolder, setSelectedReadarrFolder] = useState<number | null>(null);
+  const [selectedLivrarrFolder, setSelectedLivrarrFolder] = useState<number | null>(null);
+
+  // Preview
+  const [preview, setPreview] = useState<ImportPreviewResponse | null>(null);
+  const [skippedExpanded, setSkippedExpanded] = useState(false);
+
+  // Progress
+  const [progress, setProgress] = useState<ImportProgressResponse | null>(null);
+
+  // Undo modal
+  const [undoTarget, setUndoTarget] = useState<ImportHistoryItem | null>(null);
+
+  // Fetch Livrarr root folders
+  const { data: livrarrFolders } = useQuery({
+    queryKey: ["rootFolders"],
+    queryFn: api.listRootFolders,
+  });
+
+  // Fetch import history
+  const { data: history, refetch: refetchHistory } = useQuery({
+    queryKey: ["readarrHistory"],
+    queryFn: api.readarrHistory,
+  });
+
+  // Poll progress during import
+  useEffect(() => {
+    if (phase !== "importing") return;
+    const interval = setInterval(async () => {
+      try {
+        const p = await api.readarrProgress();
+        setProgress(p);
+        if (p.status === "completed") {
+          setPhase("completed");
+          toast.success("Import completed successfully");
+          refetchHistory();
+        } else if (p.status === "failed") {
+          setPhase("failed");
+          toast.error(p.error ?? "Import failed");
+          refetchHistory();
+        }
+      } catch {
+        // Transient error, keep polling
+      }
+    }, 2000);
+    return () => clearInterval(interval);
+  }, [phase, refetchHistory]);
+
+  // Connect mutation
+  const connectMut = useMutation({
+    mutationFn: () => api.readarrConnect(url, apiKey),
+    onMutate: () => setPhase("connecting"),
+    onSuccess: (folders) => {
+      const list = folders ?? [];
+      setReadarrFolders(list);
+      const firstReadarr = list[0];
+      setSelectedReadarrFolder(firstReadarr ? firstReadarr.id : null);
+      const firstLivrarr = livrarrFolders?.[0];
+      if (firstLivrarr) {
+        setSelectedLivrarrFolder(firstLivrarr.id);
+      }
+      setPhase("connected");
+      toast.success("Connected to Readarr");
+    },
+    onError: (err: Error) => {
+      setPhase("idle");
+      toast.error(err.message || "Failed to connect to Readarr");
+    },
+  });
+
+  // Preview mutation
+  const previewMut = useMutation({
+    mutationFn: () => {
+      if (selectedReadarrFolder === null || selectedLivrarrFolder === null) {
+        throw new Error("Select both root folders");
+      }
+      return api.readarrPreview({
+        url,
+        apiKey,
+        readarrRootFolderId: selectedReadarrFolder,
+        livrarrRootFolderId: selectedLivrarrFolder,
+      });
+    },
+    onMutate: () => setPhase("previewing"),
+    onSuccess: (data) => {
+      setPreview(data);
+      setPhase("previewed");
+    },
+    onError: (err: Error) => {
+      setPhase("connected");
+      toast.error(err.message || "Failed to generate preview");
+    },
+  });
+
+  // Start import mutation
+  const startMut = useMutation({
+    mutationFn: () => {
+      if (selectedReadarrFolder === null || selectedLivrarrFolder === null) {
+        throw new Error("Select both root folders");
+      }
+      return api.readarrStartImport({
+        url,
+        apiKey,
+        readarrRootFolderId: selectedReadarrFolder,
+        livrarrRootFolderId: selectedLivrarrFolder,
+      });
+    },
+    onSuccess: () => {
+      setPhase("importing");
+      setProgress(null);
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to start import");
+    },
+  });
+
+  // Undo mutation
+  const undoMut = useMutation({
+    mutationFn: (importId: string) => api.readarrUndo(importId),
+    onSuccess: () => {
+      toast.success("Import undone");
+      refetchHistory();
+      queryClient.invalidateQueries({ queryKey: ["works"] });
+      queryClient.invalidateQueries({ queryKey: ["authors"] });
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Failed to undo import");
+    },
+  });
+
+  // Build AI help link
+  const buildHelpLink = () => {
+    const readarrPaths = readarrFolders.map((f) => f.path).join(", ");
+    const livrarrFolder = livrarrFolders?.find((f) => f.id === selectedLivrarrFolder);
+    const livrarrPath = livrarrFolder?.path ?? "(not selected)";
+    const question = `I need help configuring Docker volume mounts for Livrarr to access my Readarr library.\nReadarr root folders: ${readarrPaths || "(not connected yet)"}\nLivrarr root folder: ${livrarrPath}\nPlease show me the docker-compose volume configuration needed.`;
+    return `/help?question=${encodeURIComponent(question)}`;
+  };
+
+  // Progress percentage
+  const progressPct =
+    progress && progress.filesTotal > 0
+      ? Math.round(
+          ((progress.authorsProcessed + progress.worksProcessed + progress.filesProcessed) /
+            (progress.authorsTotal + progress.worksTotal + progress.filesTotal)) *
+            100,
+        )
+      : 0;
+
+  return (
+    <>
+      <PageToolbar>
+        <h1 className="text-lg font-semibold text-zinc-100">Readarr Import</h1>
+      </PageToolbar>
+
+      <PageContent>
+        <div className="mx-auto max-w-3xl space-y-6">
+          {/* Warning banner */}
+          <div className="flex items-start gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3">
+            <AlertTriangle className="mt-0.5 shrink-0 text-amber-400" size={18} />
+            <div className="text-sm text-amber-200">
+              <span className="font-medium">Experimental feature.</span> This imports your Readarr
+              library into Livrarr. Your Readarr files and directories will never be modified.
+            </div>
+          </div>
+
+          {/* Mount requirement notice */}
+          <div className="flex items-start gap-3 rounded-lg border border-border bg-zinc-800/50 px-4 py-3">
+            <Info className="mt-0.5 shrink-0 text-blue-400" size={18} />
+            <div className="text-sm text-muted">
+              Readarr's library must be accessible from Livrarr's filesystem. If using Docker,
+              ensure volumes are mapped correctly.{" "}
+              <Link
+                to={buildHelpLink()}
+                className="inline-flex items-center gap-1 text-brand hover:text-brand-hover"
+              >
+                Get AI help <ExternalLink size={12} />
+              </Link>
+            </div>
+          </div>
+
+          {/* Connection section */}
+          <div className="rounded-lg border border-border bg-zinc-800/50 p-4">
+            <h2 className="mb-4 text-sm font-semibold uppercase tracking-wider text-muted">
+              Connection
+            </h2>
+            <div className="space-y-3">
+              <div>
+                <label className="mb-1 block text-sm text-muted">Readarr URL</label>
+                <input
+                  type="text"
+                  placeholder="http://localhost:8787"
+                  value={url}
+                  onChange={(e) => setUrl(e.target.value)}
+                  disabled={phase !== "idle"}
+                  className="w-full rounded border border-border bg-zinc-900 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-600 focus:border-brand focus:outline-none disabled:opacity-50"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm text-muted">API Key</label>
+                <input
+                  type="password"
+                  placeholder="Readarr API key"
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                  disabled={phase !== "idle"}
+                  className="w-full rounded border border-border bg-zinc-900 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-600 focus:border-brand focus:outline-none disabled:opacity-50"
+                />
+              </div>
+              {phase === "idle" && (
+                <button
+                  onClick={() => connectMut.mutate()}
+                  disabled={!url.trim() || !apiKey.trim()}
+                  className="inline-flex items-center gap-2 rounded bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand-hover disabled:opacity-50"
+                >
+                  Connect
+                </button>
+              )}
+              {phase === "connecting" && (
+                <button disabled className="inline-flex items-center gap-2 rounded bg-brand px-4 py-2 text-sm font-medium text-white opacity-50">
+                  <Loader2 size={14} className="animate-spin" />
+                  Connecting...
+                </button>
+              )}
+              {phase !== "idle" && phase !== "connecting" && (
+                <div className="flex items-center gap-3">
+                  <span className="inline-flex items-center gap-1.5 text-sm text-green-400">
+                    <CheckCircle2 size={14} />
+                    Connected
+                  </span>
+                  <button
+                    onClick={() => {
+                      setPhase("idle");
+                      setReadarrFolders([]);
+                      setSelectedReadarrFolder(null);
+                      setPreview(null);
+                      setProgress(null);
+                    }}
+                    className="text-sm text-muted hover:text-zinc-100"
+                  >
+                    Disconnect
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Root folder selection */}
+          {phase !== "idle" && phase !== "connecting" && (
+            <div className="rounded-lg border border-border bg-zinc-800/50 p-4">
+              <h2 className="mb-4 text-sm font-semibold uppercase tracking-wider text-muted">
+                Root Folders
+              </h2>
+              <div className="space-y-3">
+                <div>
+                  <label className="mb-1 block text-sm text-muted">Readarr Root Folder</label>
+                  <select
+                    value={selectedReadarrFolder ?? ""}
+                    onChange={(e) => setSelectedReadarrFolder(Number(e.target.value))}
+                    disabled={phase === "previewing" || phase === "importing"}
+                    className="w-full rounded border border-border bg-zinc-900 px-3 py-2 text-sm text-zinc-100 focus:border-brand focus:outline-none disabled:opacity-50"
+                  >
+                    {readarrFolders.map((f) => (
+                      <option key={f.id} value={f.id}>
+                        {f.path}
+                        {f.freeSpace != null && f.totalSpace != null
+                          ? ` (${formatBytes(f.freeSpace)} free / ${formatBytes(f.totalSpace)} total)`
+                          : ""}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="mb-1 block text-sm text-muted">Livrarr Root Folder</label>
+                  <select
+                    value={selectedLivrarrFolder ?? ""}
+                    onChange={(e) => setSelectedLivrarrFolder(Number(e.target.value))}
+                    disabled={phase === "previewing" || phase === "importing"}
+                    className="w-full rounded border border-border bg-zinc-900 px-3 py-2 text-sm text-zinc-100 focus:border-brand focus:outline-none disabled:opacity-50"
+                  >
+                    {livrarrFolders?.map((f) => (
+                      <option key={f.id} value={f.id}>
+                        {f.path} ({f.mediaType})
+                        {f.freeSpace != null && f.totalSpace != null
+                          ? ` - ${formatBytes(f.freeSpace)} free / ${formatBytes(f.totalSpace)} total`
+                          : ""}
+                      </option>
+                    ))}
+                  </select>
+                  {(!livrarrFolders || livrarrFolders.length === 0) && (
+                    <p className="mt-1 text-xs text-amber-400">
+                      No root folders configured in Livrarr.{" "}
+                      <Link to="/settings/mediamanagement" className="text-brand hover:text-brand-hover">
+                        Add one first.
+                      </Link>
+                    </p>
+                  )}
+                </div>
+                {(phase === "connected" || phase === "previewed" || phase === "completed" || phase === "failed") && (
+                  <button
+                    onClick={() => previewMut.mutate()}
+                    disabled={selectedReadarrFolder === null || selectedLivrarrFolder === null}
+                    className="inline-flex items-center gap-2 rounded bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand-hover disabled:opacity-50"
+                  >
+                    Preview Import
+                  </button>
+                )}
+                {phase === "previewing" && (
+                  <button disabled className="inline-flex items-center gap-2 rounded bg-brand px-4 py-2 text-sm font-medium text-white opacity-50">
+                    <Loader2 size={14} className="animate-spin" />
+                    Generating preview...
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Preview section */}
+          {preview && (phase === "previewed" || phase === "importing" || phase === "completed" || phase === "failed") && (
+            <div className="rounded-lg border border-border bg-zinc-800/50 p-4">
+              <h2 className="mb-4 text-sm font-semibold uppercase tracking-wider text-muted">
+                Import Preview
+              </h2>
+              <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+                <PreviewStat label="Authors" count={preview.authors.length} />
+                <PreviewStat label="Works" count={preview.works.length} />
+                <PreviewStat label="Files" count={preview.files.length} />
+                <PreviewStat label="Skipped" count={preview.skipped.length} warn />
+              </div>
+
+              {/* Skipped items */}
+              {preview.skipped.length > 0 && (
+                <div className="mt-4">
+                  <button
+                    onClick={() => setSkippedExpanded(!skippedExpanded)}
+                    className="flex items-center gap-1.5 text-sm text-muted hover:text-zinc-100"
+                  >
+                    {skippedExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                    {preview.skipped.length} skipped item{preview.skipped.length !== 1 ? "s" : ""}
+                  </button>
+                  {skippedExpanded && (
+                    <div className="mt-2 max-h-60 overflow-y-auto rounded border border-border bg-zinc-900 p-3">
+                      <div className="space-y-1.5">
+                        {preview.skipped.map((item, i) => (
+                          <div key={i} className="flex items-start gap-2 text-xs">
+                            <XCircle size={12} className="mt-0.5 shrink-0 text-red-400" />
+                            <span className="text-zinc-300">{item.name}</span>
+                            <span className="text-muted">-- {item.reason}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Confirm button */}
+              {phase === "previewed" && (
+                <button
+                  onClick={() => startMut.mutate()}
+                  disabled={startMut.isPending || (preview.authors.length === 0 && preview.works.length === 0 && preview.files.length === 0)}
+                  className="mt-4 inline-flex items-center gap-2 rounded bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
+                >
+                  {startMut.isPending ? (
+                    <>
+                      <Loader2 size={14} className="animate-spin" />
+                      Starting...
+                    </>
+                  ) : (
+                    "Confirm & Import"
+                  )}
+                </button>
+              )}
+            </div>
+          )}
+
+          {/* Progress section */}
+          {(phase === "importing" || phase === "completed" || phase === "failed") && progress && (
+            <div className="rounded-lg border border-border bg-zinc-800/50 p-4">
+              <h2 className="mb-4 text-sm font-semibold uppercase tracking-wider text-muted">
+                Import Progress
+              </h2>
+
+              {/* Progress bar */}
+              <div className="mb-4 h-3 overflow-hidden rounded-full bg-zinc-700">
+                <div
+                  className={cn(
+                    "h-full rounded-full transition-all duration-300",
+                    phase === "failed" ? "bg-red-500" : phase === "completed" ? "bg-green-500" : "bg-brand",
+                  )}
+                  style={{ width: `${progressPct}%` }}
+                />
+              </div>
+
+              {/* Status line */}
+              <div className="mb-3 flex items-center gap-2 text-sm">
+                {phase === "importing" && <Loader2 size={14} className="animate-spin text-brand" />}
+                {phase === "completed" && <CheckCircle2 size={14} className="text-green-400" />}
+                {phase === "failed" && <XCircle size={14} className="text-red-400" />}
+                <span className="text-zinc-200">
+                  {phase === "importing" && "Importing..."}
+                  {phase === "completed" && "Import completed"}
+                  {phase === "failed" && (progress.error ?? "Import failed")}
+                </span>
+                <span className="ml-auto text-muted">{progressPct}%</span>
+              </div>
+
+              {/* Counters */}
+              <div className="grid grid-cols-2 gap-2 text-xs sm:grid-cols-4">
+                <ProgressCounter label="Authors" done={progress.authorsProcessed} total={progress.authorsTotal} />
+                <ProgressCounter label="Works" done={progress.worksProcessed} total={progress.worksTotal} />
+                <ProgressCounter label="Files" done={progress.filesProcessed} total={progress.filesTotal} />
+                <ProgressCounter label="Skipped" done={progress.filesSkipped} total={null} />
+              </div>
+            </div>
+          )}
+
+          {/* Import history */}
+          {history && history.length > 0 && (
+            <div className="rounded-lg border border-border bg-zinc-800/50 p-4">
+              <h2 className="mb-4 text-sm font-semibold uppercase tracking-wider text-muted">
+                Import History
+              </h2>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-border text-left text-xs text-muted">
+                      <th className="pb-2 pr-3">Date</th>
+                      <th className="pb-2 pr-3">Source</th>
+                      <th className="pb-2 pr-3">Status</th>
+                      <th className="pb-2 pr-3 text-right">Authors</th>
+                      <th className="pb-2 pr-3 text-right">Works</th>
+                      <th className="pb-2 pr-3 text-right">Files</th>
+                      <th className="pb-2" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {history.map((item) => (
+                      <tr key={item.id} className="border-b border-border/50 last:border-0">
+                        <td className="py-2 pr-3 text-zinc-300">
+                          {formatRelativeDate(item.startedAt)}
+                        </td>
+                        <td className="py-2 pr-3 text-zinc-400 max-w-[200px] truncate">
+                          {item.sourceUrl ?? item.source}
+                        </td>
+                        <td className="py-2 pr-3">
+                          <StatusBadge status={item.status} />
+                        </td>
+                        <td className="py-2 pr-3 text-right text-zinc-300">
+                          {item.authorsCreated}
+                        </td>
+                        <td className="py-2 pr-3 text-right text-zinc-300">
+                          {item.worksCreated}
+                        </td>
+                        <td className="py-2 pr-3 text-right text-zinc-300">
+                          {item.filesImported}
+                          {item.filesSkipped > 0 && (
+                            <span className="text-muted"> ({item.filesSkipped} skipped)</span>
+                          )}
+                        </td>
+                        <td className="py-2 text-right">
+                          {item.status !== "running" && item.status !== "undone" && (
+                            <button
+                              onClick={() => setUndoTarget(item)}
+                              disabled={undoMut.isPending}
+                              className="inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-muted hover:bg-zinc-700 hover:text-zinc-100 disabled:opacity-50"
+                            >
+                              <Undo2 size={12} />
+                              Undo
+                            </button>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </div>
+      </PageContent>
+
+      {/* Undo confirmation modal */}
+      <ConfirmModal
+        open={!!undoTarget}
+        onOpenChange={(open) => !open && setUndoTarget(null)}
+        title="Undo Import"
+        description={`This will remove ${undoTarget?.authorsCreated ?? 0} authors, ${undoTarget?.worksCreated ?? 0} works, and ${undoTarget?.filesImported ?? 0} files created by this import. This cannot be reversed.`}
+        confirmLabel="Undo Import"
+        variant="danger"
+        onConfirm={async () => {
+          if (undoTarget) {
+            await undoMut.mutateAsync(undoTarget.id);
+            setUndoTarget(null);
+          }
+        }}
+      />
+    </>
+  );
+}
+
+function PreviewStat({ label, count, warn }: { label: string; count: number; warn?: boolean }) {
+  return (
+    <div className="rounded border border-border bg-zinc-900 px-3 py-2 text-center">
+      <div className={cn("text-2xl font-bold", warn && count > 0 ? "text-amber-400" : "text-zinc-100")}>
+        {count}
+      </div>
+      <div className="text-xs text-muted">{label}</div>
+    </div>
+  );
+}
+
+function ProgressCounter({
+  label,
+  done,
+  total,
+}: {
+  label: string;
+  done: number;
+  total: number | null;
+}) {
+  return (
+    <div className="rounded border border-border bg-zinc-900 px-2 py-1.5 text-center">
+      <div className="font-medium text-zinc-100">
+        {done}
+        {total !== null && <span className="text-muted">/{total}</span>}
+      </div>
+      <div className="text-muted">{label}</div>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    completed: "bg-green-500/15 text-green-400 border-green-500/30",
+    failed: "bg-red-500/15 text-red-400 border-red-500/30",
+    running: "bg-blue-500/15 text-blue-400 border-blue-500/30",
+    undone: "bg-zinc-500/15 text-zinc-400 border-zinc-500/30",
+  };
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium",
+        styles[status] ?? styles.failed,
+      )}
+    >
+      {status}
+    </span>
+  );
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -730,3 +730,57 @@ export interface ManualSearchRequest {
 export interface ManualSearchResponse {
   results: OlMatch[];
 }
+
+// Readarr Import types
+export interface ReadarrRootFolder {
+  id: number;
+  name: string | null;
+  path: string;
+  accessible: boolean | null;
+  freeSpace: number | null;
+  totalSpace: number | null;
+}
+
+export interface ImportPreviewResponse {
+  authors: ImportPreviewItem[];
+  works: ImportPreviewItem[];
+  files: ImportPreviewItem[];
+  skipped: ImportSkippedItem[];
+}
+
+export interface ImportPreviewItem {
+  name: string;
+  action: string;
+  details: string | null;
+}
+
+export interface ImportSkippedItem {
+  name: string;
+  reason: string;
+}
+
+export interface ImportProgressResponse {
+  importId: string | null;
+  status: string;
+  authorsProcessed: number;
+  authorsTotal: number;
+  worksProcessed: number;
+  worksTotal: number;
+  filesProcessed: number;
+  filesTotal: number;
+  filesSkipped: number;
+  error: string | null;
+}
+
+export interface ImportHistoryItem {
+  id: string;
+  source: string;
+  status: string;
+  startedAt: string;
+  completedAt: string | null;
+  authorsCreated: number;
+  worksCreated: number;
+  filesImported: number;
+  filesSkipped: number;
+  sourceUrl: string | null;
+}


### PR DESCRIPTION
## Summary
- Full Readarr/Bookshelf library import: connect → preview → execute with conservative dedup, hardlink-first file ops, and best-effort undo
- Readarr API client, 6 endpoints, migration 017 (imports table + import_id attribution on works/authors/library_items)
- Frontend import page with connection, preview, progress polling, history table, and undo confirmation modal
- 26 files changed, 2628 insertions

## Test plan
- [ ] Stand up Bookshelf test instance, run full connect → preview → import → verify → undo → verify cycle
- [ ] Test hardlink vs copy fallback (cross-filesystem)
- [ ] Test multi-file audiobook skip detection
- [ ] Test dedup: ISBN match, ASIN match, author+title+year match
- [ ] Test concurrent import rejection (one-at-a-time enforcement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)