### PR TITLE
list-imports: CSV import from Goodreads and Hardcover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -567,6 +568,27 @@ checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa 1.0.18",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1685,6 +1707,7 @@ dependencies = [
  "axum",
  "chrono",
  "clap",
+ "csv",
  "dashmap",
  "data-encoding",
  "futures",
@@ -1893,6 +1916,23 @@ name = "mp4ameta"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453e991b2efe96c288cbc2d03a19e353504294559ecb6c03067fff5bd824616d"
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
 
 [[package]]
 name = "nodrop"

--- a/crates/livrarr-db/migrations/019_list_import_previews.sql
+++ b/crates/livrarr-db/migrations/019_list_import_previews.sql
@@ -1,0 +1,22 @@
+-- List import preview session state for CSV imports (Goodreads, Hardcover).
+-- Rows are ephemeral — cleaned up after 1 hour by session_cleanup job.
+
+CREATE TABLE list_import_previews (
+    id             INTEGER PRIMARY KEY,
+    preview_id     TEXT NOT NULL,
+    user_id        INTEGER NOT NULL REFERENCES users(id),
+    row_index      INTEGER NOT NULL,
+    title          TEXT NOT NULL,
+    author         TEXT NOT NULL,
+    isbn_13        TEXT,
+    isbn_10        TEXT,
+    year           INTEGER,
+    source_status  TEXT,
+    source_rating  REAL,
+    preview_status TEXT NOT NULL CHECK (preview_status IN ('new', 'already_exists', 'parse_error')),
+    source         TEXT NOT NULL CHECK (source IN ('goodreads', 'hardcover')),
+    created_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX idx_lip_preview_user ON list_import_previews(preview_id, user_id);
+CREATE UNIQUE INDEX idx_lip_row ON list_import_previews(preview_id, user_id, row_index);

--- a/crates/livrarr-server/Cargo.toml
+++ b/crates/livrarr-server/Cargo.toml
@@ -32,7 +32,8 @@ getrandom = { version = "0.2", features = ["std"] }
 sha2 = "0.10"
 subtle = "2"
 hex = "0.4"
-axum = { version = "0.8", features = ["macros"] }
+axum = { version = "0.8", features = ["macros", "multipart"] }
+csv = "1"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["fs", "cors", "limit", "trace", "set-header"] }
 clap = { version = "4", features = ["derive"] }

--- a/crates/livrarr-server/src/handlers/list_import.rs
+++ b/crates/livrarr-server/src/handlers/list_import.rs
@@ -1,0 +1,825 @@
+//! List import handler — CSV imports from Goodreads and Hardcover.
+//!
+//! Two-step flow: preview (parse + local check) → confirm (OL lookup + add, batched).
+//! Undo deletes works created by the import.
+
+use axum::extract::{Multipart, Path, State};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use sqlx::Row;
+use tracing::{info, warn};
+
+use crate::handlers::work::add_work_internal;
+use crate::parsers::{self, CsvSource, ImportStatus, ParseError};
+use crate::state::AppState;
+use crate::{AddWorkRequest, ApiError, AuthContext};
+
+// ---------------------------------------------------------------------------
+// Request/Response types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreviewResponse {
+    pub preview_id: String,
+    pub source: String,
+    pub total_rows: usize,
+    pub rows: Vec<PreviewRow>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreviewRow {
+    pub row_index: usize,
+    pub title: String,
+    pub author: String,
+    pub isbn_13: Option<String>,
+    pub isbn_10: Option<String>,
+    pub year: Option<i32>,
+    pub source_status: Option<ImportStatus>,
+    pub source_rating: Option<f32>,
+    pub preview_status: String, // "new", "already_exists", "parse_error"
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfirmRequest {
+    pub preview_id: String,
+    pub row_indices: Vec<usize>,
+    pub import_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfirmResponse {
+    pub import_id: String,
+    pub results: Vec<ConfirmRowResult>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfirmRowResult {
+    pub row_index: usize,
+    pub status: String, // "added", "already_exists", "add_failed", "lookup_error"
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UndoResponse {
+    pub works_removed: i64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportSummary {
+    pub id: String,
+    pub source: String,
+    pub status: String,
+    pub started_at: String,
+    pub completed_at: Option<String>,
+    pub works_created: i64,
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/listimport/preview
+// ---------------------------------------------------------------------------
+
+pub async fn preview(
+    State(state): State<AppState>,
+    ctx: AuthContext,
+    mut multipart: Multipart,
+) -> Result<Json<PreviewResponse>, ApiError> {
+    let user_id = ctx.user.id;
+
+    // Read the first uploaded field.
+    let field = multipart
+        .next_field()
+        .await
+        .map_err(|e| ApiError::BadRequest(format!("multipart error: {e}")))?
+        .ok_or_else(|| ApiError::BadRequest("no file uploaded".into()))?;
+
+    let bytes = field
+        .bytes()
+        .await
+        .map_err(|e| ApiError::BadRequest(format!("failed to read upload: {e}")))?;
+    if bytes.len() > 20 * 1024 * 1024 {
+        return Err(ApiError::BadRequest("file too large (max 20MB)".into()));
+    }
+    let bytes = bytes.to_vec();
+    if bytes.is_empty() {
+        return Err(ApiError::BadRequest("uploaded file is empty".into()));
+    }
+
+    // Auto-detect source and parse.
+    let stripped = parsers::strip_bom_pub(&bytes);
+    let mut rdr = csv::ReaderBuilder::new()
+        .flexible(true)
+        .from_reader(stripped);
+
+    let headers = rdr
+        .headers()
+        .map_err(|e| ApiError::BadRequest(format!("invalid CSV: {e}")))?
+        .clone();
+
+    let source = parsers::detect_csv_source(&headers).map_err(|e| match e {
+        ParseError::UnknownFormat {
+            detected_headers, ..
+        } => ApiError::BadRequest(format!(
+            "unrecognized CSV format. Detected headers: {}",
+            detected_headers.join(", ")
+        )),
+        other => ApiError::BadRequest(other.to_string()),
+    })?;
+
+    let rows = match source {
+        CsvSource::Goodreads => parsers::parse_goodreads_csv(&bytes),
+        CsvSource::Hardcover => parsers::parse_hardcover_csv(&bytes),
+    }
+    .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+
+    let source_str = match source {
+        CsvSource::Goodreads => "goodreads",
+        CsvSource::Hardcover => "hardcover",
+    };
+
+    // Generate preview_id.
+    let preview_id = uuid::Uuid::new_v4().to_string();
+    let now = chrono::Utc::now().to_rfc3339();
+
+    // Check local DB for existing works by ISBN.
+    let mut preview_rows = Vec::with_capacity(rows.len());
+
+    for row in &rows {
+        let status = if row.title.is_empty() {
+            "parse_error"
+        } else {
+            // Check if work already exists by ISBN.
+            let exists = check_work_exists_by_isbn(
+                &state,
+                user_id,
+                row.isbn_13.as_deref(),
+                row.isbn_10.as_deref(),
+            )
+            .await;
+            if exists {
+                "already_exists"
+            } else {
+                "new"
+            }
+        };
+
+        // Persist to preview table.
+        sqlx::query(
+            "INSERT INTO list_import_previews \
+             (preview_id, user_id, row_index, title, author, isbn_13, isbn_10, year, \
+              source_status, source_rating, preview_status, source, created_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&preview_id)
+        .bind(user_id)
+        .bind(row.row_index as i64)
+        .bind(&row.title)
+        .bind(&row.author)
+        .bind(&row.isbn_13)
+        .bind(&row.isbn_10)
+        .bind(row.year)
+        .bind(row.status.map(|s| format!("{s:?}")))
+        .bind(row.rating)
+        .bind(status)
+        .bind(source_str)
+        .bind(&now)
+        .execute(state.db.pool())
+        .await
+        .map_err(|e| ApiError::Internal(format!("failed to persist preview: {e}")))?;
+
+        preview_rows.push(PreviewRow {
+            row_index: row.row_index,
+            title: row.title.clone(),
+            author: row.author.clone(),
+            isbn_13: row.isbn_13.clone(),
+            isbn_10: row.isbn_10.clone(),
+            year: row.year,
+            source_status: row.status,
+            source_rating: row.rating,
+            preview_status: status.to_string(),
+        });
+    }
+
+    info!(
+        user_id,
+        source = source_str,
+        rows = preview_rows.len(),
+        preview_id = %preview_id,
+        "list import preview created"
+    );
+
+    Ok(Json(PreviewResponse {
+        preview_id,
+        source: source_str.to_string(),
+        total_rows: preview_rows.len(),
+        rows: preview_rows,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/listimport/confirm
+// ---------------------------------------------------------------------------
+
+pub async fn confirm(
+    State(state): State<AppState>,
+    ctx: AuthContext,
+    Json(req): Json<ConfirmRequest>,
+) -> Result<Json<ConfirmResponse>, ApiError> {
+    let user_id = ctx.user.id;
+
+    // Validate preview exists for this user.
+    let preview_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM list_import_previews WHERE preview_id = ? AND user_id = ?",
+    )
+    .bind(&req.preview_id)
+    .bind(user_id)
+    .fetch_one(state.db.pool())
+    .await
+    .map_err(|e| ApiError::Internal(format!("preview lookup failed: {e}")))?;
+
+    if preview_count == 0 {
+        return Err(ApiError::BadRequest("preview not found or expired".into()));
+    }
+
+    // Get or create import record.
+    let import_id = if let Some(ref id) = req.import_id {
+        // Validate ownership and status.
+        let row = sqlx::query("SELECT user_id, status FROM imports WHERE id = ?")
+            .bind(id)
+            .fetch_optional(state.db.pool())
+            .await
+            .map_err(|e| ApiError::Internal(format!("import lookup failed: {e}")))?
+            .ok_or_else(|| ApiError::NotFound)?;
+
+        let owner: i64 = row.try_get("user_id").unwrap_or(0);
+        let status: String = row.try_get("status").unwrap_or_default();
+        if owner != user_id {
+            return Err(ApiError::Forbidden);
+        }
+        if status != "running" {
+            return Err(ApiError::Conflict {
+                reason: format!("import is {status}, not running"),
+            });
+        }
+        id.clone()
+    } else {
+        // Get source from preview.
+        let source: String = sqlx::query_scalar(
+            "SELECT source FROM list_import_previews WHERE preview_id = ? AND user_id = ? LIMIT 1",
+        )
+        .bind(&req.preview_id)
+        .bind(user_id)
+        .fetch_one(state.db.pool())
+        .await
+        .map_err(|e| ApiError::Internal(format!("source lookup failed: {e}")))?;
+
+        // Create new import record.
+        let id = uuid::Uuid::new_v4().to_string();
+        let now = chrono::Utc::now().to_rfc3339();
+        sqlx::query(
+            "INSERT INTO imports (id, user_id, source, status, started_at) VALUES (?, ?, ?, 'running', ?)",
+        )
+        .bind(&id)
+        .bind(user_id)
+        .bind(&source)
+        .bind(&now)
+        .execute(state.db.pool())
+        .await
+        .map_err(|e| ApiError::Internal(format!("failed to create import: {e}")))?;
+
+        id
+    };
+
+    // Process each requested row.
+    let mut results = Vec::with_capacity(req.row_indices.len());
+    let mut works_created: i64 = 0;
+
+    for &row_idx in &req.row_indices {
+        let row = sqlx::query(
+            "SELECT * FROM list_import_previews \
+             WHERE preview_id = ? AND user_id = ? AND row_index = ?",
+        )
+        .bind(&req.preview_id)
+        .bind(user_id)
+        .bind(row_idx as i64)
+        .fetch_optional(state.db.pool())
+        .await
+        .map_err(|e| ApiError::Internal(format!("row fetch failed: {e}")))?;
+
+        let row = match row {
+            Some(r) => r,
+            None => {
+                results.push(ConfirmRowResult {
+                    row_index: row_idx,
+                    status: "add_failed".into(),
+                    message: Some("row not found in preview".into()),
+                });
+                continue;
+            }
+        };
+
+        let title: String = row.try_get("title").unwrap_or_default();
+        let author: String = row.try_get("author").unwrap_or_default();
+        let isbn_13: Option<String> = row.try_get("isbn_13").ok();
+        let isbn_10: Option<String> = row.try_get("isbn_10").ok();
+        let year: Option<i32> = row.try_get("year").ok().flatten();
+
+        // OL lookup: ISBN first, fallback to title+author search.
+        let lookup_result = ol_lookup(
+            &state,
+            isbn_13.as_deref(),
+            isbn_10.as_deref(),
+            &title,
+            &author,
+            year,
+        )
+        .await;
+
+        let add_req = match lookup_result {
+            Ok(req) => req,
+            Err(msg) => {
+                results.push(ConfirmRowResult {
+                    row_index: row_idx,
+                    status: "lookup_error".into(),
+                    message: Some(msg),
+                });
+                continue;
+            }
+        };
+
+        // Try to add via existing pipeline.
+        match add_work_internal(&state, user_id, add_req).await {
+            Ok(_response) => {
+                // Tag the newly created work with import_id.
+                // The work was just created — find it by ol_key.
+                let _ = sqlx::query(
+                    "UPDATE works SET import_id = ? WHERE user_id = ? AND id = \
+                     (SELECT id FROM works WHERE user_id = ? ORDER BY id DESC LIMIT 1)",
+                )
+                .bind(&import_id)
+                .bind(user_id)
+                .bind(user_id)
+                .execute(state.db.pool())
+                .await;
+
+                works_created += 1;
+                results.push(ConfirmRowResult {
+                    row_index: row_idx,
+                    status: "added".into(),
+                    message: None,
+                });
+            }
+            Err(ApiError::Conflict { .. }) => {
+                results.push(ConfirmRowResult {
+                    row_index: row_idx,
+                    status: "already_exists".into(),
+                    message: None,
+                });
+            }
+            Err(e) => {
+                warn!(row_idx, error = %e, "list import: add_work failed");
+                results.push(ConfirmRowResult {
+                    row_index: row_idx,
+                    status: "add_failed".into(),
+                    message: Some(format!("{e}")),
+                });
+            }
+        }
+    }
+
+    // Update import counters.
+    let _ = sqlx::query("UPDATE imports SET works_created = works_created + ? WHERE id = ?")
+        .bind(works_created)
+        .bind(&import_id)
+        .execute(state.db.pool())
+        .await;
+
+    info!(
+        user_id,
+        import_id = %import_id,
+        batch_size = req.row_indices.len(),
+        works_created,
+        "list import confirm batch processed"
+    );
+
+    Ok(Json(ConfirmResponse { import_id, results }))
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/listimport/{import_id}/complete
+// ---------------------------------------------------------------------------
+
+pub async fn complete(
+    State(state): State<AppState>,
+    ctx: AuthContext,
+    Path(import_id): Path<String>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let result = sqlx::query(
+        "UPDATE imports SET status = 'completed', completed_at = ? \
+         WHERE id = ? AND user_id = ? AND status = 'running'",
+    )
+    .bind(&now)
+    .bind(&import_id)
+    .bind(ctx.user.id)
+    .execute(state.db.pool())
+    .await
+    .map_err(|e| ApiError::Internal(format!("complete failed: {e}")))?;
+
+    if result.rows_affected() == 0 {
+        return Err(ApiError::NotFound);
+    }
+
+    info!(user_id = ctx.user.id, import_id = %import_id, "list import completed");
+
+    Ok(Json(serde_json::json!({ "status": "completed" })))
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v1/listimport/{import_id}
+// ---------------------------------------------------------------------------
+
+pub async fn undo(
+    State(state): State<AppState>,
+    ctx: AuthContext,
+    Path(import_id): Path<String>,
+) -> Result<Json<UndoResponse>, ApiError> {
+    let user_id = ctx.user.id;
+
+    // Validate import exists and belongs to user.
+    let row = sqlx::query("SELECT status FROM imports WHERE id = ? AND user_id = ?")
+        .bind(&import_id)
+        .bind(user_id)
+        .fetch_optional(state.db.pool())
+        .await
+        .map_err(|e| ApiError::Internal(format!("import lookup failed: {e}")))?
+        .ok_or_else(|| ApiError::NotFound)?;
+
+    let status: String = row.try_get("status").unwrap_or_default();
+    if status == "undone" {
+        return Err(ApiError::Conflict {
+            reason: "import already undone".into(),
+        });
+    }
+
+    // Delete works created by this import for this user.
+    // Also delete associated library_items, grabs, history, etc. via cascading
+    // or explicit cleanup. For alpha3, works is sufficient — imported works
+    // won't have library items (they're metadata-only, no files).
+    let deleted = sqlx::query("DELETE FROM works WHERE import_id = ? AND user_id = ?")
+        .bind(&import_id)
+        .bind(user_id)
+        .execute(state.db.pool())
+        .await
+        .map_err(|e| ApiError::Internal(format!("undo delete failed: {e}")))?
+        .rows_affected() as i64;
+
+    // Mark import as undone.
+    let _ = sqlx::query("UPDATE imports SET status = 'undone' WHERE id = ?")
+        .bind(&import_id)
+        .execute(state.db.pool())
+        .await;
+
+    info!(user_id, import_id = %import_id, works_removed = deleted, "list import undone");
+
+    Ok(Json(UndoResponse {
+        works_removed: deleted,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/listimport
+// ---------------------------------------------------------------------------
+
+pub async fn list(
+    State(state): State<AppState>,
+    ctx: AuthContext,
+) -> Result<Json<Vec<ImportSummary>>, ApiError> {
+    let rows = sqlx::query(
+        "SELECT id, source, status, started_at, completed_at, works_created \
+         FROM imports WHERE user_id = ? AND source IN ('goodreads', 'hardcover') \
+         ORDER BY started_at DESC LIMIT 50",
+    )
+    .bind(ctx.user.id)
+    .fetch_all(state.db.pool())
+    .await
+    .map_err(|e| ApiError::Internal(format!("list imports failed: {e}")))?;
+
+    let imports: Vec<ImportSummary> = rows
+        .iter()
+        .map(|r| ImportSummary {
+            id: r.try_get("id").unwrap_or_default(),
+            source: r.try_get("source").unwrap_or_default(),
+            status: r.try_get("status").unwrap_or_default(),
+            started_at: r.try_get("started_at").unwrap_or_default(),
+            completed_at: r.try_get("completed_at").ok().flatten(),
+            works_created: r.try_get("works_created").unwrap_or(0),
+        })
+        .collect();
+
+    Ok(Json(imports))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Check if a work already exists for this user by ISBN-13 or ISBN-10.
+async fn check_work_exists_by_isbn(
+    state: &AppState,
+    user_id: i64,
+    isbn_13: Option<&str>,
+    isbn_10: Option<&str>,
+) -> bool {
+    // Check ISBN-13 via works table.
+    if let Some(isbn) = isbn_13 {
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM works WHERE user_id = ? AND isbn_13 = ?")
+                .bind(user_id)
+                .bind(isbn)
+                .fetch_one(state.db.pool())
+                .await
+                .unwrap_or(0);
+        if count > 0 {
+            return true;
+        }
+
+        // Also check external_ids table.
+        let ext_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM external_ids ei \
+             JOIN works w ON ei.work_id = w.id \
+             WHERE w.user_id = ? AND ei.id_type = 'isbn_13' AND ei.id_value = ?",
+        )
+        .bind(user_id)
+        .bind(isbn)
+        .fetch_one(state.db.pool())
+        .await
+        .unwrap_or(0);
+        if ext_count > 0 {
+            return true;
+        }
+    }
+
+    // Check ISBN-10 via external_ids.
+    if let Some(isbn) = isbn_10 {
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM external_ids ei \
+             JOIN works w ON ei.work_id = w.id \
+             WHERE w.user_id = ? AND ei.id_type = 'isbn_10' AND ei.id_value = ?",
+        )
+        .bind(user_id)
+        .bind(isbn)
+        .fetch_one(state.db.pool())
+        .await
+        .unwrap_or(0);
+        if count > 0 {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Look up a book on OpenLibrary by ISBN (preferred) or title+author search.
+/// Returns an AddWorkRequest on success, or an error message.
+async fn ol_lookup(
+    state: &AppState,
+    isbn_13: Option<&str>,
+    isbn_10: Option<&str>,
+    title: &str,
+    author: &str,
+    year: Option<i32>,
+) -> Result<AddWorkRequest, String> {
+    // Try ISBN lookup first (more precise).
+    let isbn = isbn_13.or(isbn_10);
+    if let Some(isbn) = isbn {
+        if let Some(req) = ol_isbn_lookup(state, isbn).await {
+            return Ok(req);
+        }
+    }
+
+    // Fallback: title + author search.
+    ol_search(state, title, author, year).await
+}
+
+/// OpenLibrary ISBN lookup → AddWorkRequest.
+async fn ol_isbn_lookup(state: &AppState, isbn: &str) -> Option<AddWorkRequest> {
+    let url = format!("https://openlibrary.org/isbn/{isbn}.json");
+    let resp = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        state.http_client.get(&url).send(),
+    )
+    .await
+    .ok()?
+    .ok()?;
+
+    if !resp.status().is_success() {
+        return None;
+    }
+
+    let data: serde_json::Value = resp.json().await.ok()?;
+
+    // ISBN endpoint returns an edition — we need to follow the works link.
+    let works_key = data
+        .get("works")
+        .and_then(|w| w.as_array())
+        .and_then(|a| a.first())
+        .and_then(|w| w.get("key"))
+        .and_then(|k| k.as_str())?;
+
+    let ol_key = works_key.trim_start_matches("/works/").to_string();
+
+    // Fetch the work record for title/author.
+    let work_url = format!("https://openlibrary.org{works_key}.json");
+    let work_resp = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        state.http_client.get(&work_url).send(),
+    )
+    .await
+    .ok()?
+    .ok()?;
+
+    let work_data: serde_json::Value = work_resp.json().await.ok()?;
+
+    let title = work_data
+        .get("title")
+        .and_then(|t| t.as_str())
+        .unwrap_or("Unknown")
+        .to_string();
+
+    // Get author from the work's authors array.
+    let author_keys = work_data
+        .get("authors")
+        .and_then(|a| a.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let (author_name, author_ol_key) = if let Some(first) = author_keys.first() {
+        let author_key = first
+            .get("author")
+            .and_then(|a| a.get("key"))
+            .or_else(|| first.get("key"))
+            .and_then(|k| k.as_str())
+            .unwrap_or("");
+
+        let author_ol = author_key.trim_start_matches("/authors/").to_string();
+
+        // Fetch author name from OL author endpoint.
+        let name = if !author_key.is_empty() {
+            let author_url = format!("https://openlibrary.org{author_key}.json");
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                state.http_client.get(&author_url).send(),
+            )
+            .await
+            {
+                Ok(Ok(resp)) => resp
+                    .json::<serde_json::Value>()
+                    .await
+                    .ok()
+                    .and_then(|v| v.get("name")?.as_str().map(|s| s.to_string()))
+                    .unwrap_or_else(|| "Unknown".to_string()),
+                _ => "Unknown".to_string(),
+            }
+        } else {
+            "Unknown".to_string()
+        };
+
+        (name, Some(author_ol).filter(|s| !s.is_empty()))
+    } else {
+        ("Unknown".to_string(), None)
+    };
+
+    let year = data
+        .get("publish_date")
+        .and_then(|d| d.as_str())
+        .and_then(|d| {
+            // Extract 4-digit year from publish_date string.
+            d.chars()
+                .collect::<String>()
+                .split_whitespace()
+                .find_map(|w| w.parse::<i32>().ok().filter(|&y| y > 1000 && y < 3000))
+        });
+
+    let cover_url = data
+        .get("covers")
+        .and_then(|c| c.as_array())
+        .and_then(|a| a.first())
+        .and_then(|c| c.as_i64())
+        .map(|c| format!("https://covers.openlibrary.org/b/id/{c}-L.jpg"));
+
+    Some(AddWorkRequest {
+        ol_key: Some(ol_key),
+        title,
+        author_name,
+        author_ol_key,
+        year,
+        cover_url,
+        metadata_source: None,
+        language: None,
+        detail_url: None,
+    })
+}
+
+/// OpenLibrary search by title + author → AddWorkRequest.
+async fn ol_search(
+    state: &AppState,
+    title: &str,
+    author: &str,
+    csv_year: Option<i32>,
+) -> Result<AddWorkRequest, String> {
+    let search_term = format!("{title} {author}");
+
+    let resp = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        state
+            .http_client
+            .get("https://openlibrary.org/search.json")
+            .query(&[
+                ("q", search_term.as_str()),
+                ("limit", "5"),
+                (
+                    "fields",
+                    "key,title,author_name,author_key,first_publish_year,cover_i",
+                ),
+            ])
+            .send(),
+    )
+    .await
+    .map_err(|_| "OpenLibrary search timed out".to_string())?
+    .map_err(|e| format!("OpenLibrary request failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("OpenLibrary returned {}", resp.status()));
+    }
+
+    let data: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("OpenLibrary parse error: {e}"))?;
+
+    let docs = data
+        .get("docs")
+        .and_then(|d| d.as_array())
+        .ok_or_else(|| "no results from OpenLibrary".to_string())?;
+
+    let doc = docs
+        .first()
+        .ok_or_else(|| format!("no OpenLibrary results for '{title}' by '{author}'"))?;
+
+    let key = doc
+        .get("key")
+        .and_then(|k| k.as_str())
+        .ok_or_else(|| "missing key in OL result".to_string())?;
+    let ol_key = key.trim_start_matches("/works/").to_string();
+
+    let result_title = doc
+        .get("title")
+        .and_then(|t| t.as_str())
+        .unwrap_or(title)
+        .to_string();
+
+    let author_name = doc
+        .get("author_name")
+        .and_then(|a| a.as_array())
+        .and_then(|a| a.first())
+        .and_then(|a| a.as_str())
+        .unwrap_or(author)
+        .to_string();
+
+    let author_ol_key = doc
+        .get("author_key")
+        .and_then(|a| a.as_array())
+        .and_then(|a| a.first())
+        .and_then(|a| a.as_str())
+        .map(|k| k.trim_start_matches("/authors/").to_string());
+
+    let year = doc
+        .get("first_publish_year")
+        .and_then(|y| y.as_i64())
+        .map(|y| y as i32)
+        .or(csv_year);
+
+    let cover_url = doc
+        .get("cover_i")
+        .and_then(|c| c.as_i64())
+        .map(|c| format!("https://covers.openlibrary.org/b/id/{c}-L.jpg"));
+
+    Ok(AddWorkRequest {
+        ol_key: Some(ol_key),
+        title: result_title,
+        author_name,
+        author_ol_key,
+        year,
+        cover_url,
+        metadata_source: None,
+        language: None,
+        detail_url: None,
+    })
+}

--- a/crates/livrarr-server/src/handlers/mod.rs
+++ b/crates/livrarr-server/src/handlers/mod.rs
@@ -9,6 +9,7 @@ pub mod filesystem;
 pub mod history;
 pub mod import;
 pub mod indexer;
+pub mod list_import;
 pub mod manual_import;
 pub mod mediacover;
 pub mod notification;

--- a/crates/livrarr-server/src/jobs.rs
+++ b/crates/livrarr-server/src/jobs.rs
@@ -876,6 +876,19 @@ async fn session_cleanup_tick(state: AppState, _cancel: CancellationToken) -> Re
     if count > 0 {
         debug!("session cleanup: deleted {count} expired sessions");
     }
+
+    // Clean up stale list import preview rows (older than 1 hour).
+    let cutoff = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
+    let preview_count = sqlx::query("DELETE FROM list_import_previews WHERE created_at < ?")
+        .bind(&cutoff)
+        .execute(state.db.pool())
+        .await
+        .map(|r| r.rows_affected())
+        .unwrap_or(0);
+    if preview_count > 0 {
+        debug!("session cleanup: deleted {preview_count} stale list import previews");
+    }
+
     Ok(())
 }
 

--- a/crates/livrarr-server/src/lib.rs
+++ b/crates/livrarr-server/src/lib.rs
@@ -13,6 +13,7 @@ pub mod handlers;
 pub mod jobs;
 pub mod matching;
 pub mod middleware;
+pub mod parsers;
 pub mod readarr_client;
 pub mod router;
 pub mod state;

--- a/crates/livrarr-server/src/parsers.rs
+++ b/crates/livrarr-server/src/parsers.rs
@@ -1,0 +1,436 @@
+//! CSV parsers for Goodreads and Hardcover book list exports.
+//!
+//! Both parsers produce `Vec<ImportRow>` from raw CSV bytes. They handle:
+//! - BOM stripping (common in Windows CSV exports)
+//! - Goodreads `="..."` ISBN wrapping
+//! - Case-insensitive header matching
+//! - Missing optional columns
+
+use std::collections::HashMap;
+
+/// Detected CSV source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CsvSource {
+    Goodreads,
+    Hardcover,
+}
+
+/// Reading status from the source platform (display-only for alpha3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ImportStatus {
+    WantToRead,
+    Reading,
+    Read,
+    Paused,
+    #[serde(rename = "dnf")]
+    DNF,
+}
+
+/// A single parsed row from a CSV import.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportRow {
+    pub row_index: usize,
+    pub title: String,
+    pub author: String,
+    pub isbn_13: Option<String>,
+    pub isbn_10: Option<String>,
+    pub year: Option<i32>,
+    pub status: Option<ImportStatus>,
+    pub rating: Option<f32>,
+}
+
+/// Auto-detect CSV source from headers.
+pub fn detect_csv_source(headers: &csv::StringRecord) -> Result<CsvSource, ParseError> {
+    let lower: Vec<String> = headers.iter().map(|h| h.trim().to_lowercase()).collect();
+
+    // Goodreads: has "exclusive shelf" column (unique to Goodreads)
+    if lower.contains(&"exclusive shelf".to_string()) {
+        return Ok(CsvSource::Goodreads);
+    }
+
+    // Goodreads: has "book id" column (also unique)
+    if lower.contains(&"book id".to_string()) {
+        return Ok(CsvSource::Goodreads);
+    }
+
+    // Hardcover: has "status" column and no "exclusive shelf"
+    // Also check for hardcover-specific patterns
+    if lower.contains(&"status".to_string())
+        && (lower.contains(&"isbn_13".to_string()) || lower.contains(&"isbn 13".to_string()))
+    {
+        return Ok(CsvSource::Hardcover);
+    }
+
+    // Hardcover: check for "date started" / "date finished" (Hardcover-specific)
+    if lower.contains(&"date started".to_string()) || lower.contains(&"date finished".to_string()) {
+        return Ok(CsvSource::Hardcover);
+    }
+
+    Err(ParseError::UnknownFormat {
+        detected_headers: headers.iter().map(|h| h.to_string()).collect(),
+    })
+}
+
+/// Parse a Goodreads CSV export.
+pub fn parse_goodreads_csv(bytes: &[u8]) -> Result<Vec<ImportRow>, ParseError> {
+    let bytes = strip_bom(bytes);
+    let mut rdr = csv::ReaderBuilder::new().flexible(true).from_reader(bytes);
+
+    let headers = rdr
+        .headers()
+        .map_err(|e| ParseError::CsvError(e.to_string()))?
+        .clone();
+    let col = build_column_map(&headers);
+
+    let title_idx = col
+        .get("title")
+        .ok_or(ParseError::MissingColumn("Title".into()))?;
+    let author_idx = col
+        .get("author")
+        .ok_or(ParseError::MissingColumn("Author".into()))?;
+    let isbn13_idx = col.get("isbn13");
+    let isbn_idx = col.get("isbn");
+    let year_idx = col.get("original publication year");
+    let shelf_idx = col.get("exclusive shelf");
+    let rating_idx = col.get("my rating");
+
+    let mut rows = Vec::new();
+    for (i, result) in rdr.records().enumerate() {
+        let record = match result {
+            Ok(r) => r,
+            Err(_) => {
+                rows.push(ImportRow {
+                    row_index: i,
+                    title: String::new(),
+                    author: String::new(),
+                    isbn_13: None,
+                    isbn_10: None,
+                    year: None,
+                    status: None,
+                    rating: None,
+                });
+                continue;
+            }
+        };
+
+        let title = get_field(&record, *title_idx).unwrap_or_default();
+        let author = get_field(&record, *author_idx).unwrap_or_default();
+
+        // Goodreads wraps ISBNs in ="..." for Excel safety
+        let isbn_13 = isbn13_idx
+            .and_then(|idx| get_field(&record, *idx))
+            .map(|v| strip_excel_wrapper(&v))
+            .filter(|v| !v.is_empty());
+
+        let isbn_10 = isbn_idx
+            .and_then(|idx| get_field(&record, *idx))
+            .map(|v| strip_excel_wrapper(&v))
+            .filter(|v| !v.is_empty());
+
+        let year = year_idx
+            .and_then(|idx| get_field(&record, *idx))
+            .and_then(|v| v.parse::<i32>().ok());
+
+        let status = shelf_idx
+            .and_then(|idx| get_field(&record, *idx))
+            .and_then(|v| match v.to_lowercase().as_str() {
+                "to-read" => Some(ImportStatus::WantToRead),
+                "currently-reading" => Some(ImportStatus::Reading),
+                "read" => Some(ImportStatus::Read),
+                _ => None,
+            });
+
+        let rating = rating_idx
+            .and_then(|idx| get_field(&record, *idx))
+            .and_then(|v| v.parse::<f32>().ok())
+            .filter(|&r| r > 0.0);
+
+        rows.push(ImportRow {
+            row_index: i,
+            title,
+            author,
+            isbn_13,
+            isbn_10,
+            year,
+            status,
+            rating,
+        });
+    }
+
+    Ok(rows)
+}
+
+/// Parse a Hardcover CSV export.
+pub fn parse_hardcover_csv(bytes: &[u8]) -> Result<Vec<ImportRow>, ParseError> {
+    let bytes = strip_bom(bytes);
+    let mut rdr = csv::ReaderBuilder::new().flexible(true).from_reader(bytes);
+
+    let headers = rdr
+        .headers()
+        .map_err(|e| ParseError::CsvError(e.to_string()))?
+        .clone();
+    let col = build_column_map(&headers);
+
+    let title_idx = col
+        .get("title")
+        .ok_or(ParseError::MissingColumn("Title".into()))?;
+    let author_idx = col
+        .get("author")
+        .ok_or(ParseError::MissingColumn("Author".into()))?;
+    let isbn13_idx = col.get("isbn_13").or_else(|| col.get("isbn 13"));
+    let isbn10_idx = col.get("isbn_10").or_else(|| col.get("isbn 10"));
+    let status_idx = col.get("status");
+    let rating_idx = col.get("rating");
+
+    let mut rows = Vec::new();
+    for (i, result) in rdr.records().enumerate() {
+        let record = match result {
+            Ok(r) => r,
+            Err(_) => {
+                rows.push(ImportRow {
+                    row_index: i,
+                    title: String::new(),
+                    author: String::new(),
+                    isbn_13: None,
+                    isbn_10: None,
+                    year: None,
+                    status: None,
+                    rating: None,
+                });
+                continue;
+            }
+        };
+
+        let title = get_field(&record, *title_idx).unwrap_or_default();
+        let author = get_field(&record, *author_idx).unwrap_or_default();
+
+        let isbn_13 = isbn13_idx
+            .and_then(|idx| get_field(&record, *idx))
+            .filter(|v| !v.is_empty());
+
+        let isbn_10 = isbn10_idx
+            .and_then(|idx| get_field(&record, *idx))
+            .filter(|v| !v.is_empty());
+
+        let status = status_idx
+            .and_then(|idx| get_field(&record, *idx))
+            .and_then(|v| match v.to_lowercase().as_str() {
+                "want to read" => Some(ImportStatus::WantToRead),
+                "currently reading" => Some(ImportStatus::Reading),
+                "read" => Some(ImportStatus::Read),
+                "paused" => Some(ImportStatus::Paused),
+                "did not finish" | "dnf" => Some(ImportStatus::DNF),
+                _ => None,
+            });
+
+        let rating = rating_idx
+            .and_then(|idx| get_field(&record, *idx))
+            .and_then(|v| v.parse::<f32>().ok())
+            .filter(|&r| r > 0.0);
+
+        rows.push(ImportRow {
+            row_index: i,
+            title,
+            author,
+            isbn_13,
+            isbn_10,
+            year: None, // Hardcover CSV doesn't include year
+            status,
+            rating,
+        });
+    }
+
+    Ok(rows)
+}
+
+/// Errors from CSV parsing.
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    #[error("CSV parse error: {0}")]
+    CsvError(String),
+
+    #[error("missing required column: {0}")]
+    MissingColumn(String),
+
+    #[error("unknown CSV format — detected headers: {detected_headers:?}")]
+    UnknownFormat { detected_headers: Vec<String> },
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Strip UTF-8 BOM if present (public for handler use).
+pub fn strip_bom_pub(bytes: &[u8]) -> &[u8] {
+    strip_bom(bytes)
+}
+
+/// Strip UTF-8 BOM if present.
+fn strip_bom(bytes: &[u8]) -> &[u8] {
+    if bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        &bytes[3..]
+    } else {
+        bytes
+    }
+}
+
+/// Build a case-insensitive column name → index map.
+fn build_column_map(headers: &csv::StringRecord) -> HashMap<String, usize> {
+    headers
+        .iter()
+        .enumerate()
+        .map(|(i, h)| (h.trim().to_lowercase(), i))
+        .collect()
+}
+
+/// Get a trimmed field value from a record, returning None if out of bounds or empty.
+fn get_field(record: &csv::StringRecord, idx: usize) -> Option<String> {
+    record
+        .get(idx)
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+/// Strip Goodreads Excel-safe ISBN wrapping: `="0060590297"` → `0060590297`.
+fn strip_excel_wrapper(val: &str) -> String {
+    let trimmed = val.trim();
+    if trimmed.starts_with("=\"") && trimmed.ends_with('"') {
+        trimmed[2..trimmed.len() - 1].to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_excel_wrapper() {
+        assert_eq!(strip_excel_wrapper("=\"0060590297\""), "0060590297");
+        assert_eq!(strip_excel_wrapper("=\"9780060590291\""), "9780060590291");
+        assert_eq!(strip_excel_wrapper("plain"), "plain");
+        assert_eq!(strip_excel_wrapper(""), "");
+    }
+
+    #[test]
+    fn test_strip_bom() {
+        let with_bom = b"\xEF\xBB\xBFhello";
+        assert_eq!(strip_bom(with_bom), b"hello");
+
+        let without_bom = b"hello";
+        assert_eq!(strip_bom(without_bom), b"hello");
+    }
+
+    #[test]
+    fn test_detect_goodreads() {
+        let headers = csv::StringRecord::from(vec![
+            "Book Id",
+            "Title",
+            "Author",
+            "ISBN",
+            "ISBN13",
+            "My Rating",
+            "Exclusive Shelf",
+        ]);
+        assert_eq!(detect_csv_source(&headers).unwrap(), CsvSource::Goodreads);
+    }
+
+    #[test]
+    fn test_detect_hardcover() {
+        let headers = csv::StringRecord::from(vec![
+            "Title",
+            "Author",
+            "ISBN_13",
+            "ISBN_10",
+            "Rating",
+            "Status",
+            "Date Started",
+        ]);
+        assert_eq!(detect_csv_source(&headers).unwrap(), CsvSource::Hardcover);
+    }
+
+    #[test]
+    fn test_detect_unknown() {
+        let headers = csv::StringRecord::from(vec!["Foo", "Bar", "Baz"]);
+        assert!(detect_csv_source(&headers).is_err());
+    }
+
+    #[test]
+    fn test_parse_goodreads_csv() {
+        let csv_data = b"Book Id,Title,Author,ISBN,ISBN13,My Rating,Exclusive Shelf,Original Publication Year\n\
+            1234,Dune,Frank Herbert,=\"0441172717\",=\"9780441172719\",5,read,1965\n\
+            5678,\"The Left Hand of Darkness\",Ursula K. Le Guin,=\"0441478123\",=\"9780441478125\",4,to-read,1969\n";
+
+        let rows = parse_goodreads_csv(csv_data).unwrap();
+        assert_eq!(rows.len(), 2);
+
+        assert_eq!(rows[0].title, "Dune");
+        assert_eq!(rows[0].author, "Frank Herbert");
+        assert_eq!(rows[0].isbn_13.as_deref(), Some("9780441172719"));
+        assert_eq!(rows[0].isbn_10.as_deref(), Some("0441172717"));
+        assert_eq!(rows[0].year, Some(1965));
+        assert_eq!(rows[0].status, Some(ImportStatus::Read));
+        assert_eq!(rows[0].rating, Some(5.0));
+
+        assert_eq!(rows[1].title, "The Left Hand of Darkness");
+        assert_eq!(rows[1].status, Some(ImportStatus::WantToRead));
+    }
+
+    #[test]
+    fn test_parse_goodreads_csv_with_bom() {
+        let mut csv_data = vec![0xEF, 0xBB, 0xBF]; // BOM
+        csv_data.extend_from_slice(
+            b"Book Id,Title,Author,ISBN,ISBN13,My Rating,Exclusive Shelf\n\
+              1,Test Book,Test Author,=\"\",=\"\",0,read\n",
+        );
+
+        let rows = parse_goodreads_csv(&csv_data).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].title, "Test Book");
+        // Empty ISBNs after stripping should be None
+        assert!(rows[0].isbn_13.is_none());
+        assert!(rows[0].isbn_10.is_none());
+        // Rating 0 should be filtered out
+        assert!(rows[0].rating.is_none());
+    }
+
+    #[test]
+    fn test_parse_hardcover_csv() {
+        let csv_data = b"Title,Author,ISBN_13,ISBN_10,Rating,Status\n\
+            Dune,Frank Herbert,9780441172719,0441172717,5,Read\n\
+            Neuromancer,William Gibson,,,4.5,Want to Read\n";
+
+        let rows = parse_hardcover_csv(csv_data).unwrap();
+        assert_eq!(rows.len(), 2);
+
+        assert_eq!(rows[0].title, "Dune");
+        assert_eq!(rows[0].isbn_13.as_deref(), Some("9780441172719"));
+        assert_eq!(rows[0].status, Some(ImportStatus::Read));
+
+        assert_eq!(rows[1].title, "Neuromancer");
+        assert!(rows[1].isbn_13.is_none());
+        assert_eq!(rows[1].status, Some(ImportStatus::WantToRead));
+        assert_eq!(rows[1].rating, Some(4.5));
+    }
+
+    #[test]
+    fn test_parse_goodreads_quoted_commas() {
+        let csv_data = b"Title,Author,ISBN,ISBN13,My Rating,Exclusive Shelf\n\
+            \"Good Omens: The Nice and Accurate Prophecies of Agnes Nutter, Witch\",\"Gaiman, Neil\",=\"0060853980\",=\"9780060853983\",5,read\n";
+
+        let rows = parse_goodreads_csv(csv_data).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].title,
+            "Good Omens: The Nice and Accurate Prophecies of Agnes Nutter, Witch"
+        );
+        assert_eq!(rows[0].author, "Gaiman, Neil");
+    }
+}

--- a/crates/livrarr-server/src/router.rs
+++ b/crates/livrarr-server/src/router.rs
@@ -258,6 +258,18 @@ pub fn build_router(state: AppState, ui_dir: std::path::PathBuf) -> Router {
             "/import/readarr/{import_id}",
             delete(handlers::readarr_import::undo),
         )
+        // List imports (CSV: Goodreads, Hardcover)
+        .route("/listimport", get(handlers::list_import::list))
+        .route("/listimport/preview", post(handlers::list_import::preview))
+        .route("/listimport/confirm", post(handlers::list_import::confirm))
+        .route(
+            "/listimport/{import_id}/complete",
+            post(handlers::list_import::complete),
+        )
+        .route(
+            "/listimport/{import_id}",
+            delete(handlers::list_import::undo),
+        )
         // Library files
         .route("/workfile", get(handlers::workfile::list))
         .route(

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,9 @@ const MissingPage = lazy(() => import("@/pages/wanted/MissingPage"));
 const ReadarrImportPage = lazy(
   () => import("@/pages/import/ReadarrImportPage"),
 );
+const ListImportPage = lazy(
+  () => import("@/pages/lists/ListImportPage"),
+);
 
 // Settings (lazy)
 const MediaManagementPage = lazy(
@@ -182,6 +185,14 @@ export function App() {
                 }
               />
               <Route
+                path="lists"
+                element={
+                  <LazyPage>
+                    <ListImportPage />
+                  </LazyPage>
+                }
+              />
+              <Route
                 path="unmapped"
                 element={
                   <LazyPage>
@@ -293,10 +304,7 @@ export function App() {
                 path="settings/customformats"
                 element={<ComingSoonPage title="Custom Formats" />}
               />
-              <Route
-                path="settings/importlists"
-                element={<ComingSoonPage title="Import Lists" />}
-              />
+              {/* Import Lists moved to /lists (main nav) */}
               <Route
                 path="settings/notifications"
                 element={<ComingSoonPage title="Notifications" />}

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -69,6 +69,11 @@ import type {
   ImportPreviewResponse,
   ImportProgressResponse,
   ImportHistoryItem,
+  ListImportPreviewResponse,
+  ListImportConfirmRequest,
+  ListImportConfirmResponse,
+  ListImportSummary,
+  ListImportUndoResponse,
 } from "@/types/api";
 
 // Setup
@@ -468,3 +473,31 @@ export const readarrHistory = () =>
   apiFetch<ImportHistoryItem[]>("/import/readarr/history");
 export const readarrUndo = (importId: string) =>
   apiFetch<void>(`/import/readarr/${importId}`, { method: "DELETE" });
+
+// List imports (CSV: Goodreads, Hardcover)
+export const listImportPreview = async (file: File): Promise<ListImportPreviewResponse> => {
+  const token = (await import("./client")).getToken();
+  const formData = new FormData();
+  formData.append("file", file);
+  const res = await fetch("/api/v1/listimport/preview", {
+    method: "POST",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    body: formData,
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ message: res.statusText }));
+    throw new Error(err.message || res.statusText);
+  }
+  return res.json();
+};
+export const listImportConfirm = (req: ListImportConfirmRequest) =>
+  apiFetch<ListImportConfirmResponse>("/listimport/confirm", {
+    method: "POST",
+    body: JSON.stringify(req),
+  });
+export const listImportComplete = (importId: string) =>
+  apiFetch<{ status: string }>(`/listimport/${importId}/complete`, { method: "POST" });
+export const listImportUndo = (importId: string) =>
+  apiFetch<ListImportUndoResponse>(`/listimport/${importId}`, { method: "DELETE" });
+export const listImportHistory = () =>
+  apiFetch<ListImportSummary[]>("/listimport");

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -57,6 +57,7 @@ const navGroups: NavGroup[] = [
     children: [
       { label: "Works", path: "/", icon: <BookOpen size={18} /> },
       { label: "Authors", path: "/author", icon: <Users size={18} /> },
+      { label: "Lists", path: "/lists", icon: <Import size={18} /> },
       { label: "Add New", path: "/search", icon: <PlusCircle size={18} /> },
       {
         label: "Missing",
@@ -164,13 +165,6 @@ const navGroups: NavGroup[] = [
         label: "Custom Formats",
         path: "/settings/customformats",
         icon: <Tag size={18} />,
-        adminOnly: true,
-        greyed: true,
-      },
-      {
-        label: "Import Lists",
-        path: "/settings/importlists",
-        icon: <Import size={18} />,
         adminOnly: true,
         greyed: true,
       },

--- a/frontend/src/pages/lists/ListImportPage.tsx
+++ b/frontend/src/pages/lists/ListImportPage.tsx
@@ -1,0 +1,459 @@
+import { useState, useCallback, useRef } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  Upload,
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  AlertCircle,
+  Undo2,
+  BookOpen,
+  FileText,
+} from "lucide-react";
+import { PageContent } from "@/components/Page/PageContent";
+import { PageToolbar } from "@/components/Page/PageToolbar";
+import { ConfirmModal } from "@/components/Page/ConfirmModal";
+import * as api from "@/api";
+import { formatRelativeDate } from "@/utils/format";
+import { cn } from "@/utils/cn";
+import type {
+  ListImportPreviewResponse,
+  ListImportConfirmRowResult,
+} from "@/types/api";
+
+type Phase = "idle" | "uploading" | "previewed" | "confirming" | "done";
+
+const BATCH_SIZE = 10;
+
+export default function ListImportPage() {
+  const queryClient = useQueryClient();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [preview, setPreview] = useState<ListImportPreviewResponse | null>(null);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [progress, setProgress] = useState({ done: 0, total: 0 });
+  const [results, setResults] = useState<ListImportConfirmRowResult[]>([]);
+  const [currentImportId, setCurrentImportId] = useState<string | null>(null);
+  const [undoTarget, setUndoTarget] = useState<string | null>(null);
+
+  // Fetch import history for undo.
+  const { data: history, refetch: refetchHistory } = useQuery({
+    queryKey: ["list-import-history"],
+    queryFn: api.listImportHistory,
+  });
+
+  // File drop handler.
+  const handleFile = useCallback(async (file: File) => {
+    if (!file.name.endsWith(".csv")) {
+      toast.error("Please upload a CSV file");
+      return;
+    }
+    setPhase("uploading");
+    try {
+      const resp = await api.listImportPreview(file);
+      setPreview(resp);
+      // Auto-select "new" rows, deselect others.
+      const sel = new Set<number>();
+      for (const row of resp.rows) {
+        if (row.previewStatus === "new") sel.add(row.rowIndex);
+      }
+      setSelected(sel);
+      setPhase("previewed");
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : "Upload failed");
+      setPhase("idle");
+    }
+  }, []);
+
+  const onDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      const file = e.dataTransfer.files[0];
+      if (file) handleFile(file);
+    },
+    [handleFile]
+  );
+
+  const onFileSelect = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) handleFile(file);
+    },
+    [handleFile]
+  );
+
+  // Toggle row selection.
+  const toggleRow = (idx: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) next.delete(idx);
+      else next.add(idx);
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    if (!preview) return;
+    const newRows = preview.rows.filter((r) => r.previewStatus === "new");
+    if (selected.size === newRows.length) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(newRows.map((r) => r.rowIndex)));
+    }
+  };
+
+  // Batch confirm.
+  const handleConfirm = async () => {
+    if (!preview || selected.size === 0) return;
+    setPhase("confirming");
+    setResults([]);
+
+    const indices = Array.from(selected);
+    setProgress({ done: 0, total: indices.length });
+
+    let importId: string | undefined;
+    const allResults: ListImportConfirmRowResult[] = [];
+
+    for (let i = 0; i < indices.length; i += BATCH_SIZE) {
+      const batch = indices.slice(i, i + BATCH_SIZE);
+      try {
+        const resp = await api.listImportConfirm({
+          previewId: preview.previewId,
+          rowIndices: batch,
+          importId,
+        });
+        importId = resp.importId;
+        allResults.push(...resp.results);
+        setProgress({ done: Math.min(i + BATCH_SIZE, indices.length), total: indices.length });
+        setResults([...allResults]);
+      } catch (e: unknown) {
+        toast.error(e instanceof Error ? e.message : "Import batch failed");
+        break;
+      }
+    }
+
+    // Mark complete.
+    if (importId) {
+      try {
+        await api.listImportComplete(importId);
+      } catch {
+        // Non-critical — import still worked.
+      }
+      setCurrentImportId(importId);
+    }
+
+    setPhase("done");
+    queryClient.invalidateQueries({ queryKey: ["works"] });
+    refetchHistory();
+
+    const added = allResults.filter((r) => r.status === "added").length;
+    const exists = allResults.filter((r) => r.status === "already_exists").length;
+    const failed = allResults.filter(
+      (r) => r.status === "add_failed" || r.status === "lookup_error"
+    ).length;
+    toast.success(`Import complete: ${added} added, ${exists} existing, ${failed} failed`);
+  };
+
+  // Undo.
+  const handleUndo = async (importId: string) => {
+    try {
+      const resp = await api.listImportUndo(importId);
+      toast.success(`Removed ${resp.worksRemoved} imported works`);
+      queryClient.invalidateQueries({ queryKey: ["works"] });
+      refetchHistory();
+      setUndoTarget(null);
+      if (currentImportId === importId) {
+        reset();
+      }
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : "Undo failed");
+    }
+  };
+
+  const reset = () => {
+    setPhase("idle");
+    setPreview(null);
+    setSelected(new Set());
+    setResults([]);
+    setCurrentImportId(null);
+    setProgress({ done: 0, total: 0 });
+  };
+
+  // Status badge for preview rows.
+  const statusBadge = (status: string) => {
+    switch (status) {
+      case "new":
+        return <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-green-500/20 text-green-400"><CheckCircle2 size={12} /> New</span>;
+      case "already_exists":
+        return <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground"><AlertCircle size={12} /> Exists</span>;
+      case "parse_error":
+        return <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-red-500/20 text-red-400"><XCircle size={12} /> Error</span>;
+      default:
+        return null;
+    }
+  };
+
+  const confirmStatusIcon = (status: string) => {
+    switch (status) {
+      case "added":
+        return <CheckCircle2 size={14} className="text-green-400" />;
+      case "already_exists":
+        return <AlertCircle size={14} className="text-muted-foreground" />;
+      default:
+        return <XCircle size={14} className="text-red-400" />;
+    }
+  };
+
+  return (
+    <>
+      <PageToolbar>
+        <h1 className="text-lg font-semibold text-foreground">List Import</h1>
+      </PageToolbar>
+      <PageContent>
+        {/* Import history (undo) */}
+        {history && history.filter((h) => h.status !== "undone").length > 0 && (
+          <div className="mb-6 p-4 rounded-lg border border-border bg-card">
+            <h3 className="text-sm font-medium text-foreground mb-3">Recent Imports</h3>
+            <div className="space-y-2">
+              {history
+                .filter((h) => h.status !== "undone")
+                .slice(0, 5)
+                .map((imp) => (
+                  <div key={imp.id} className="flex items-center justify-between text-sm">
+                    <div className="flex items-center gap-2">
+                      <span className="capitalize text-muted-foreground">{imp.source}</span>
+                      <span className="text-foreground">{imp.worksCreated} works</span>
+                      <span className="text-muted-foreground">{formatRelativeDate(imp.startedAt)}</span>
+                      <span className={cn(
+                        "text-xs px-1.5 py-0.5 rounded",
+                        imp.status === "completed" ? "bg-green-500/20 text-green-400" :
+                        imp.status === "running" ? "bg-yellow-500/20 text-yellow-400" :
+                        "bg-muted text-muted-foreground"
+                      )}>{imp.status}</span>
+                    </div>
+                    <button
+                      onClick={() => setUndoTarget(imp.id)}
+                      className="flex items-center gap-1 text-xs text-red-400 hover:text-red-300"
+                    >
+                      <Undo2 size={12} /> Undo
+                    </button>
+                  </div>
+                ))}
+            </div>
+          </div>
+        )}
+
+        {/* Phase: idle — source selection + file drop */}
+        {phase === "idle" && (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {[
+              {
+                name: "Goodreads",
+                icon: BookOpen,
+                instructions: "Export your library from goodreads.com/review/import — click \"Export Library\" at the top.",
+              },
+              {
+                name: "Hardcover",
+                icon: FileText,
+                instructions: "Export your library from hardcover.app/account/exports — download the CSV file.",
+              },
+            ].map((src) => (
+              <div
+                key={src.name}
+                className="p-6 rounded-lg border-2 border-dashed border-border hover:border-primary/50 transition-colors cursor-pointer bg-card"
+                onDragOver={(e) => e.preventDefault()}
+                onDrop={onDrop}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <div className="flex flex-col items-center gap-3 text-center">
+                  <src.icon size={32} className="text-muted-foreground" />
+                  <h3 className="text-lg font-medium text-foreground">{src.name}</h3>
+                  <p className="text-sm text-muted-foreground">{src.instructions}</p>
+                  <div className="flex items-center gap-2 mt-2 text-sm text-primary">
+                    <Upload size={16} />
+                    Drop CSV here or click to browse
+                  </div>
+                </div>
+              </div>
+            ))}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".csv"
+              className="hidden"
+              onChange={onFileSelect}
+            />
+          </div>
+        )}
+
+        {/* Phase: uploading */}
+        {phase === "uploading" && (
+          <div className="flex items-center justify-center gap-3 p-12 text-muted-foreground">
+            <Loader2 size={20} className="animate-spin" />
+            Parsing CSV...
+          </div>
+        )}
+
+        {/* Phase: previewed — show table */}
+        {phase === "previewed" && preview && (
+          <div>
+            <div className="flex items-center justify-between mb-4">
+              <div>
+                <h3 className="text-sm font-medium text-foreground">
+                  {preview.totalRows} books from{" "}
+                  <span className="capitalize">{preview.source}</span>
+                </h3>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Match status is based on local ISBN lookup — some books may resolve differently during import.
+                  Reading status and ratings are shown for reference but are not imported yet.
+                </p>
+              </div>
+              <div className="flex gap-2">
+                <button onClick={reset} className="btn btn-secondary text-sm">
+                  Cancel
+                </button>
+                <button
+                  onClick={handleConfirm}
+                  disabled={selected.size === 0}
+                  className="btn btn-primary text-sm"
+                >
+                  Import {selected.size} Selected
+                </button>
+              </div>
+            </div>
+
+            <div className="border border-border rounded-lg overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border bg-muted/50">
+                    <th className="p-3 w-8">
+                      <input type="checkbox" checked={preview.rows.filter((r) => r.previewStatus === "new").length === selected.size && selected.size > 0} onChange={toggleAll} />
+                    </th>
+                    <th className="p-3 text-left text-muted-foreground font-medium">Title</th>
+                    <th className="p-3 text-left text-muted-foreground font-medium">Author</th>
+                    <th className="p-3 text-left text-muted-foreground font-medium">ISBN</th>
+                    <th className="p-3 text-left text-muted-foreground font-medium">Status</th>
+                    <th className="p-3 text-left text-muted-foreground font-medium">Rating</th>
+                    <th className="p-3 text-left text-muted-foreground font-medium">Match</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {preview.rows.map((row) => (
+                    <tr
+                      key={row.rowIndex}
+                      className={cn(
+                        "border-b border-border last:border-0 hover:bg-muted/30",
+                        row.previewStatus !== "new" && "opacity-50"
+                      )}
+                    >
+                      <td className="p-3">
+                        <input
+                          type="checkbox"
+                          checked={selected.has(row.rowIndex)}
+                          onChange={() => toggleRow(row.rowIndex)}
+                          disabled={row.previewStatus === "parse_error"}
+                        />
+                      </td>
+                      <td className="p-3 text-foreground">{row.title || <span className="italic text-muted-foreground">—</span>}</td>
+                      <td className="p-3 text-muted-foreground">{row.author}</td>
+                      <td className="p-3 text-muted-foreground font-mono text-xs">{row.isbn13 || row.isbn10 || "—"}</td>
+                      <td className="p-3 text-muted-foreground text-xs">{row.sourceStatus || "—"}</td>
+                      <td className="p-3 text-muted-foreground">{row.sourceRating || "—"}</td>
+                      <td className="p-3">{statusBadge(row.previewStatus)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {/* Phase: confirming — progress */}
+        {phase === "confirming" && (
+          <div className="p-8">
+            <div className="flex items-center gap-3 mb-4">
+              <Loader2 size={20} className="animate-spin text-primary" />
+              <span className="text-foreground">
+                Importing... {progress.done} / {progress.total}
+              </span>
+            </div>
+            <div className="w-full bg-muted rounded-full h-2">
+              <div
+                className="bg-primary h-2 rounded-full transition-all duration-300"
+                style={{ width: `${progress.total ? (progress.done / progress.total) * 100 : 0}%` }}
+              />
+            </div>
+            {results.length > 0 && (
+              <div className="mt-4 max-h-64 overflow-y-auto space-y-1">
+                {results.map((r) => (
+                  <div key={r.rowIndex} className="flex items-center gap-2 text-sm">
+                    {confirmStatusIcon(r.status)}
+                    <span className="text-muted-foreground">Row {r.rowIndex + 1}:</span>
+                    <span className="text-foreground">{r.status}</span>
+                    {r.message && <span className="text-muted-foreground text-xs">({r.message})</span>}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Phase: done — summary */}
+        {phase === "done" && (
+          <div className="p-8">
+            <div className="flex items-center gap-3 mb-4">
+              <CheckCircle2 size={24} className="text-green-400" />
+              <h3 className="text-lg font-medium text-foreground">Import Complete</h3>
+            </div>
+            <div className="grid grid-cols-3 gap-4 mb-6">
+              <div className="p-3 rounded bg-green-500/10 text-center">
+                <div className="text-2xl font-bold text-green-400">
+                  {results.filter((r) => r.status === "added").length}
+                </div>
+                <div className="text-xs text-muted-foreground">Added</div>
+              </div>
+              <div className="p-3 rounded bg-muted text-center">
+                <div className="text-2xl font-bold text-muted-foreground">
+                  {results.filter((r) => r.status === "already_exists").length}
+                </div>
+                <div className="text-xs text-muted-foreground">Already Existed</div>
+              </div>
+              <div className="p-3 rounded bg-red-500/10 text-center">
+                <div className="text-2xl font-bold text-red-400">
+                  {results.filter((r) => r.status === "add_failed" || r.status === "lookup_error").length}
+                </div>
+                <div className="text-xs text-muted-foreground">Failed</div>
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <button onClick={reset} className="btn btn-primary text-sm">
+                Import Another
+              </button>
+              {currentImportId && (
+                <button
+                  onClick={() => setUndoTarget(currentImportId)}
+                  className="btn btn-secondary text-sm flex items-center gap-1 text-red-400"
+                >
+                  <Undo2 size={14} /> Undo This Import
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Undo confirmation modal */}
+        <ConfirmModal
+          open={!!undoTarget}
+          onOpenChange={(open) => !open && setUndoTarget(null)}
+          title="Undo Import"
+          description="This will remove all works added by this import. This cannot be undone."
+          confirmLabel="Undo Import"
+          variant="danger"
+          onConfirm={() => { if (undoTarget) handleUndo(undoTarget); }}
+        />
+      </PageContent>
+    </>
+  );
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -784,3 +784,53 @@ export interface ImportHistoryItem {
   filesSkipped: number;
   sourceUrl: string | null;
 }
+
+// List Imports (CSV: Goodreads, Hardcover)
+export interface ListImportPreviewRow {
+  rowIndex: number;
+  title: string;
+  author: string;
+  isbn13: string | null;
+  isbn10: string | null;
+  year: number | null;
+  sourceStatus: string | null;
+  sourceRating: number | null;
+  previewStatus: "new" | "already_exists" | "parse_error";
+}
+
+export interface ListImportPreviewResponse {
+  previewId: string;
+  source: string;
+  totalRows: number;
+  rows: ListImportPreviewRow[];
+}
+
+export interface ListImportConfirmRequest {
+  previewId: string;
+  rowIndices: number[];
+  importId?: string;
+}
+
+export interface ListImportConfirmRowResult {
+  rowIndex: number;
+  status: "added" | "already_exists" | "add_failed" | "lookup_error";
+  message: string | null;
+}
+
+export interface ListImportConfirmResponse {
+  importId: string;
+  results: ListImportConfirmRowResult[];
+}
+
+export interface ListImportSummary {
+  id: string;
+  source: string;
+  status: string;
+  startedAt: string;
+  completedAt: string | null;
+  worksCreated: number;
+}
+
+export interface ListImportUndoResponse {
+  worksRemoved: number;
+}


### PR DESCRIPTION
## Summary
- One-shot CSV import from Goodreads and Hardcover exports
- Two-step flow: preview (parse + local ISBN check, fast) → confirm (OL lookup + add, batched with progress)
- Undo support: delete all works from an import via `import_id` on works table
- Frontend: Lists page with drag-drop file upload, preview table, batch confirm with progress bar, undo
- 9 unit tests for CSV parsers (BOM, `="..."` ISBNs, quoted commas, header auto-detection)

## New files
- `crates/livrarr-db/migrations/019_list_import_previews.sql`
- `crates/livrarr-server/src/parsers.rs` — Goodreads + Hardcover CSV parsers
- `crates/livrarr-server/src/handlers/list_import.rs` — 5 endpoints
- `frontend/src/pages/lists/ListImportPage.tsx`

## Endpoints
- `POST /api/v1/listimport/preview` — multipart file upload, returns preview_id + rows
- `POST /api/v1/listimport/confirm` — batched, creates/appends import record
- `POST /api/v1/listimport/{id}/complete` — marks import done
- `DELETE /api/v1/listimport/{id}` — undo (deletes works by import_id)
- `GET /api/v1/listimport` — list import history

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets` — zero new warnings
- [x] `cargo test --workspace --exclude livrarr-metadata` — all pass (9 new parser tests)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual test: upload real Goodreads CSV export
- [ ] Manual test: upload real Hardcover CSV export

🤖 Generated with [Claude Code](https://claude.com/claude-code)