### PR TITLE
 Add ARM64/Raspberry Pi support documentation

### DIFF
--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -1,0 +1,38 @@
+name: Build ARM64 Docker Image
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/livrarr:arm64

--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ main ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -36,3 +39,5 @@ jobs:
           platforms: linux/arm64
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/livrarr:arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -1,15 +1,31 @@
 ## ARM64 / Raspberry Pi Support
 
-The official image is amd64 only. To build for ARM64 (e.g. Raspberry Pi 4) I've done the following:
+The official image is amd64 only. For ARM64 (e.g. Raspberry Pi 4), a pre-built image is available:
+
+```yaml
+services:
+  livrarr:
+    image: ghcr.io/edmunek/livrarr:arm64
+    container_name: livrarr
+    ports:
+      - 8789:8789
+    volumes:
+      - /your/config:/config
+      - /your/books:/books
+      - /your/downloads:/downloads
+    restart: unless-stopped
+```
+
+### Build it yourself
+If you prefer to build your own ARM64 image:
 
 1. Fork this repository
 2. Create `.github/workflows/build-arm64.yml` with the workflow from this fork
 3. Run the workflow via **Actions → Build ARM64 Docker Image → Run workflow**
 4. The image will be pushed to your GitHub Container Registry as `ghcr.io/YOUR_USERNAME/livrarr:arm64`
 
-> Note: Build time is few hours on GitHub Actions free tier (first run). 
+> Note: Build time is approximately 6 hours on GitHub Actions free tier (first run).
 > Subsequent runs are faster due to layer caching.
-
 
 # Livrarr
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+## ARM64 / Raspberry Pi Support
+
+The official image is amd64 only. To build for ARM64 (e.g. Raspberry Pi 4) I've done the following:
+
+1. Fork this repository
+2. Create `.github/workflows/build-arm64.yml` with the workflow from this fork
+3. Run the workflow via **Actions → Build ARM64 Docker Image → Run workflow**
+4. The image will be pushed to your GitHub Container Registry as `ghcr.io/YOUR_USERNAME/livrarr:arm64`
+
+> Note: Build time is few hours on GitHub Actions free tier (first run). 
+> Subsequent runs are faster due to layer caching.
+
+
 # Livrarr
 
 **Self-hosted ebook and audiobook library manager.** Built for the \*arr ecosystem — finds, grabs, and organizes your books the way Sonarr does for TV.


### PR DESCRIPTION
Adds documentation for running Livrarr on ARM64 devices (e.g. Raspberry Pi 4).
   
   Includes:
   - Pre-built ARM64 image available at ghcr.io/edmunek/livrarr:arm64
   - GitHub Actions workflow for building your own ARM64 image
   - docker-compose example for ARM64 deployment